### PR TITLE
Rework opsworks profile syncing

### DIFF
--- a/lib/cluster/user.rb
+++ b/lib/cluster/user.rb
@@ -21,7 +21,7 @@ module Cluster
       )
       syncer.deny_privileges_for_unconfigured_users
       syncer.create_missing_users
-      syncer.create_missing_opsworks_user_profiles
+      syncer.sync_opsworks_user_profiles
       syncer.set_user_permissions_from_config
     end
   end


### PR DESCRIPTION
User profile syncing has been changed in the following ways:
- If a user does not have an SSH key and a cluster_config has a key, we
  update the users's profile with that key.
- If a user has a key already, we do not make any changes to it.

This means that basically the first time we see a key for an opsworks user
profile, we use that key and save it to the profile.

If you must change a user profile ssh key, you can update it in the opsworks
console or remove it and run "stack:users:init" with an updated 
cluster_config.json.
