### PR TITLE
Improve waiters. Includes:

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source "https://rubygems.org"
 
-gem 'aws-sdk', '~> 2.1.8'
+# gem 'aws-sdk', '~> 2.1.8'
+gem 'aws-sdk', git: 'https://github.com/harvard-dce/aws-sdk-ruby', branch: 'master'
+
 gem 'rake', '~> 10.4.2'
 
 gem 'rspec-core', '~> 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/harvard-dce/aws-sdk-ruby
+  revision: ffe1373a699bf4a6d9d370e9525a3c1dad8cb614
+  branch: master
+  specs:
+    aws-sdk (2.1.14)
+      aws-sdk-resources (= 2.1.14)
+    aws-sdk-core (2.1.14)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.1.14)
+      aws-sdk-core (= 2.1.14)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -7,12 +19,6 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    aws-sdk (2.1.8)
-      aws-sdk-resources (= 2.1.8)
-    aws-sdk-core (2.1.8)
-      jmespath (~> 1.0)
-    aws-sdk-resources (2.1.8)
-      aws-sdk-core (= 2.1.8)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     coderay (1.1.0)
@@ -55,7 +61,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk (~> 2.1.8)
+  aws-sdk!
   climate_control
   diffy (~> 3.0.7)
   erubis (~> 2.7.0)

--- a/lib/cluster/instance_profile.rb
+++ b/lib/cluster/instance_profile.rb
@@ -44,6 +44,10 @@ module Cluster
           instance_profile_name: instance_profile_name
         )
 
+        # This seems an adequate amount of time to wait for the
+        # instance profile to propagate, unfortunately
+        # I can't find a way to test for propagation.
+        sleep 10
         wait_until_instance_profile_exists(instance_profile_name)
       end
       construct_instance(instance_profile_name)

--- a/lib/cluster/permissions_syncer.rb
+++ b/lib/cluster/permissions_syncer.rb
@@ -76,9 +76,20 @@ module Cluster
           )
         end
       end
+      wait_for_users_to_propagate
     end
 
     private
+
+    def wait_for_users_to_propagate
+      puts 'Waiting for changes (if any) to propagate across the cluster'
+      sleep 10
+      user_deployment_command = Cluster::Deployment.all.find do |deployment|
+        deployment.command.args['recipes'].include?('ssh_users')
+      end
+      user_deployment_command &&
+        self.class.wait_until_deployment_completed(user_deployment_command.deployment_id)
+    end
 
     def create_user_profile(user_arn, ssh_key)
       self.class.opsworks_client.create_user_profile(

--- a/lib/cluster/waiters.rb
+++ b/lib/cluster/waiters.rb
@@ -1,88 +1,103 @@
 module Cluster
   module Waiters
     module ClassMethods
+
+      def wait_until_deployment_completed(deployment_id)
+        print "Waiting for deployment, command, or recipe to execute successfully: "
+        opsworks_client.wait_until(
+          :deployment_successful, deployment_ids: [deployment_id]
+        ) do |w|
+          ::Cluster::Instance.apply_wait_options(w)
+        end
+        puts " done!"
+      end
+
       def wait_until_stack_build_completed(cfn_stack_id)
+        print "Waiting for vpc infrastructure to be built for #{vpc_name}: "
         cloudformation_client.wait_until(
           :stack_create_complete, stack_name: cfn_stack_id
         ) do |w|
-          w.before_wait do |attempts, response|
-            puts "Waiting for vpc infrastructure to be built for #{vpc_name}, attempt ##{attempts}"
-          end
+          ::Cluster::Instance.apply_wait_options(w)
         end
+        puts " done!"
       end
 
       def wait_until_stack_delete_completed(cfn_stack_id)
+        print "Waiting for vpc infrastructure to be deleted for #{vpc_name}: "
         cloudformation_client.wait_until(
           :stack_delete_complete, stack_name: cfn_stack_id
         ) do |w|
-          w.before_wait do |attempts, response|
-            puts "Waiting for vpc infrastructure to be deleted for #{vpc_name}, attempt ##{attempts}"
-          end
+          ::Cluster::Instance.apply_wait_options(w)
         end
+        puts " done!"
       end
 
       def wait_until_app_exists(app_id)
-        opsworks_client.wait_until(
-          :app_exists, app_ids: [app_id]
-        ) do |w|
-          w.before_wait do |attempts, response|
-            puts "Waiting for app to exist: #{app_id}, attempt ##{attempts}"
-          end
+        print "Waiting for app to exist: #{app_id}: "
+          opsworks_client.wait_until(:app_exists, app_ids: [app_id]) do |w|
+          ::Cluster::Instance.apply_wait_options(w)
         end
+        puts " done!"
 
         yield if block_given?
       end
 
       def wait_until_opsworks_instances_started(instance_ids = [])
+        print "Ensuring #{instance_ids.length} instances are started: "
         opsworks_client.wait_until(
           :instance_online, instance_ids: instance_ids
         ) do |w|
-          w.max_attempts = 150
-          w.delay = 20
-          w.before_wait do |attempts, response|
-            puts "Starting instances #{instance_ids.join(', ')}, attempt ##{attempts}"
-          end
+          ::Cluster::Instance.apply_wait_options(w)
         end
 
+        puts " done!"
         yield if block_given?
       end
 
       def wait_until_opsworks_instances_stopped(instance_ids = [])
+        print "Ensuring #{instance_ids.length} instances are stopped: "
         opsworks_client.wait_until(
           :instance_stopped, instance_ids: instance_ids
         ) do |w|
-          w.before_wait do |attempts, response|
-            puts "Stopping instance #{instance_ids.join(', ')}, attempt ##{attempts}"
-          end
+          binding.pry
+          ::Cluster::Instance.apply_wait_options(w)
         end
 
+        puts " done!"
         yield if block_given?
       end
 
       def wait_until_user_exists(user_name)
-        iam_client.wait_until(
-          :user_exists,
-          user_name: user_name
-        ) do |w|
-          w.before_wait do |attempts, response|
-            puts "Checking if user #{user_name} exists, attempt: ##{attempts}"
-          end
+        print "Checking if user #{user_name} exists: "
+        iam_client.wait_until(:user_exists, user_name: user_name) do |w|
+          ::Cluster::Instance.apply_wait_options(w)
         end
 
+        puts " done!"
         yield if block_given?
       end
 
       def wait_until_instance_profile_exists(instance_profile_name)
+        print "Checking if instance profile #{instance_profile_name} exists: "
         iam_client.wait_until(
           :instance_profile_exists,
           instance_profile_name: instance_profile_name
         ) do |w|
-          w.before_wait do |attempts, response|
-            puts "Checking if instance profile #{instance_profile_name} exists, attempt: ##{attempts}"
-          end
+          ::Cluster::Instance.apply_wait_options(w)
         end
 
+        puts " done!"
         yield if block_given?
+      end
+
+      def apply_wait_options(w)
+        w.tap do |w|
+          w.max_attempts = 600
+          w.delay = 5
+          w.before_wait do |attempts, response|
+            print '.'
+          end
+        end
       end
     end
 


### PR DESCRIPTION
- Better output
- Wait for deployments, commands, and user permission changes to successfully 
  propagate across the cluster
