### PR TITLE
MATT-1727-distribute-to-s3 

### DIFF
--- a/lib/cluster/base.rb
+++ b/lib/cluster/base.rb
@@ -43,7 +43,7 @@ module Cluster
           "Statement" =>  [
             {
               "Action" =>  [
-                "s3:GetObject",
+                "s3:*",
                 "cloudwatch:*",
                 "sns:CreateTopic",
                 "opsworks:DescribeInstances",


### PR DESCRIPTION
Changed S3 rights to \* so that we can distribute/retract files.
