### PR TITLE
Allow java unit tests to be run during a redeploy

### DIFF
--- a/lib/cluster/deployment.rb
+++ b/lib/cluster/deployment.rb
@@ -17,6 +17,10 @@ module Cluster
       deploy_app(deploy_action: :force_deploy)
     end
 
+    def self.redeploy_app_with_unit_tests
+      deploy_app(deploy_action: :force_deploy, skip_java_unit_tests: false)
+    end
+
     def self.deploy_app(custom_json_overrides = {})
       stack = Cluster::Stack.with_existing_stack
       app = App.find_or_create

--- a/lib/tasks/deployment.rake
+++ b/lib/tasks/deployment.rake
@@ -9,6 +9,11 @@ namespace :deployment do
     Cluster::Deployment.redeploy_app
   end
 
+  desc Cluster::RakeDocs.new('deployment:redeploy_app_with_unit_tests').desc
+  task redeploy_app_with_unit_tests: ['cluster:configtest', 'cluster:config_sync_check', 'cluster:production_failsafe'] do
+    Cluster::Deployment.redeploy_app_with_unit_tests
+  end
+
   task rollback_app: ['cluster:configtest', 'cluster:config_sync_check'] do
     Cluster::Deployment.rollback_app
   end

--- a/lib/tasks/docs/deployment:deploy_app.txt
+++ b/lib/tasks/docs/deployment:deploy_app.txt
@@ -26,4 +26,4 @@ revision will still be running.
 
 SEE ALSO:
 
-cluster:new, matterhorn:restart
+cluster:new, matterhorn:restart, deployments:redeploy_app

--- a/lib/tasks/docs/deployment:redeploy_app.txt
+++ b/lib/tasks/docs/deployment:redeploy_app.txt
@@ -10,4 +10,4 @@ only be used in development or staging clusters.
 
 SEE ALSO:
 
-deployment:deploy_app
+deployment:deploy_app, deployment:redeploy_app_with_unit_tests

--- a/lib/tasks/docs/deployment:redeploy_app_with_unit_tests.txt
+++ b/lib/tasks/docs/deployment:redeploy_app_with_unit_tests.txt
@@ -1,0 +1,8 @@
+Run unit tests while force deploying the most recent app revision
+
+Simlar to `deployment:redeploy_app`, except this also runs unit tests during
+the redeploy.
+
+SEE ALSO:
+
+deployment:deploy_app, deployment:redeploy_app


### PR DESCRIPTION
Create the "deployment:redeploy_app_with_unit_tests" rake task which does
exactly what it says - it redeploys while running the java unit tests.
