### PR TITLE
Execute mh-ui-testing tasks in opsworks cluster context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## TO BE RELEASED
 
 * Provide convenience defaults when executing `cluster:new`.
+* Execution of ghost inspector tests via `./bin/mh_ghost` script.
 
 ## 1.6.1 - 6/08/2016
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ matterhorn cluster.
 ## Requirements
 
 * Ruby 2
+* Python 2.7+, including virtualenv 
 * Appropriately configured aws rights linked to an access key
 * A POSIX operating system
 

--- a/README.ui-testing.md
+++ b/README.ui-testing.md
@@ -1,0 +1,91 @@
+# Ghost Inspector Testing
+
+Run [Ghost Inspector](http://ghostinspector.com/) tests on your `mh-opsworks` cluster using the `./bin/mh_ghost` script. This script acts as a wrapper around the ghost inspector commands provided by the
+[mh-ui-testing](https://github.com/harvard-dce/mh-ui-testing) command-line tool. It can be used to execute test suites or individual tests. The hostnames, auth settings of your cluster, as well as your ghost inspector api key, will be automatically injected into the calls made to the ghost inspector API.
+
+### Usage
+
+The basic invocation looks like:
+
+`./bin/mh_ghost [node] [options]`
+
+where `[node]` is one of `admin1`, `engage1`, etc., and `[options]` must at least specify one of `--test=[test id]` or `--suite=[suite id]`. Test and suite ids can be obtained from Ghost Inspector: copy/paste from either the test/suite URL in your browser, or from the "API Access" links available in the lower-right section of the test/suite overview page.
+
+#### API key
+
+`mh_ghost` can automatically find and insert your Ghost Inspector API key from one of two places:
+
+##### `secrets.json`
+
+    {
+      "access_key_id": "...",
+      "secret_access_key": "...",
+      "cluster_config_bucket_name": "my-cluster-configs",
+      "ghostinspector_key": "[api key]"
+    }
+
+##### Environment variable
+
+e.g., in your `.bashrc` file put:
+
+    export GHOSTINSPECTOR_KEY=[api key]
+
+##### Command-line OPTIONS
+
+You can also provide the api key value on the command-line:
+
+    ./bin/mh_ghost --test=[test id] --key=[api key]
+
+#### Additional options
+
+To see a full list of options, run `./bin/mh_ghost --help`. **Note**: while the options shown by `--help` are correct, the command invocation shown will be for the wrapped `mh-ui-testing` command. Just remember to replace `mh gi exec` with `./bin/mh_ghost`.
+
+    Usage: mh gi exec [OPTIONS]
+
+      Execute tests
+
+      Options:
+        --runners INTEGER  num tests to run concurrently [default: 4]
+        -H, --host TEXT    host/ip of remote admin node
+        --var TEXT         extra test variable(s); repeatable
+        --key TEXT         ghost inspector API key
+        --suite TEXT       ID of a ghost inspector suite
+        --test TEXT        ID of a ghost inspector test
+        --help             Show this message and exit.
+
+
+### Test variables
+
+By default `./bin/mh_ghost` will pass the following test variables to the Ghost Inspector API call:
+
+* admin_user
+* admin_pass
+* target_host
+
+Additional variables can be included in the API execution request by using the `--var` option. The format is:
+
+    `--var name=value`
+
+You can pass as many extra `--var` options as the test/suite expects.
+
+### Parallel execution
+
+Up to `n` tests can be executed concurrently, where `n` is the value of the `--runners` option. By default, `--runners` will get the number of cpus on your local machine / 2.
+
+For example, if you have a suite containing 6 tests and the computer you are executing the tests from has 4 cpus, the test runner will create and distribute the tests to 2 concurrent subprocesses.
+
+## Development notes
+
+The `mh-ui-testing` tool is installed during `./bin/setup` along with a python virtualenv (at `./.venv`).
+
+The `mh-ui-testing` release tag to install is defined in `./bin/setup` but alternate versions can be installed by calling `pip` directly:
+
+    .venv/bin/pip install -U --force-reinstall mh-ui-testing==[version]
+
+or:
+
+    .venv/bin/pip install -U -e /path/to/local/mh-ui-testing
+
+or:
+
+    .venv/bin/pip install -U git+https://github.com/harvard-dce/mh-ui-testing.git@branch-or-sha

--- a/bin/mh_ghost
+++ b/bin/mh_ghost
@@ -1,0 +1,68 @@
+#!.venv/bin/python
+
+import os
+import sys
+import json
+from fabric.api import local, hide, prefix, settings, abort
+from fabric.colors import cyan
+
+
+def get_cluster_config():
+    with open('.mhopsworks.rc') as f:
+        rc = dict(x.strip().split('=') for x in f.readlines())
+    with open(rc['cluster']) as f:
+        config = json.load(f)
+    with open(rc['secrets']) as f:
+        config['secrets'] = json.load(f)
+    return config
+
+if __name__ == '__main__':
+
+    target_host = None
+    shell_vars = {}
+
+    if '--help' in sys.argv:
+        # remove any target node arg before pass through
+        if sys.argv[1].startswith('admin') or sys.argv[1].startswith('engage'):
+            sys.argv.pop(1)
+        cmd = ' '.join(sys.argv[1:])
+    else:
+        # first arg should be the target node to test against (admin1, engage1, etc)
+        node = sys.argv.pop(1)
+
+        cluster_config = get_cluster_config()
+        admin_auth = cluster_config['stack']['chef']['custom_json']['admin_auth']
+
+        with settings(hide('running', 'warnings'), warn_only=True):
+            target_host = local('./bin/rake stack:instances:public_dns hostname=%s' % node,
+                                capture=True)
+            if not target_host.succeeded:
+                abort("invalid node: " + target_host)
+            print cyan("using node " + node + ", hostname " + str(target_host))
+
+        # re-quote remaining args
+        test_args = [x.replace(' ', '\ ') for x in sys.argv[1:]]
+        test_args += [
+            '--var target_host=%s' % target_host,
+            '--var admin_user=%s' % admin_auth['user'],
+            '--var admin_pass=%s' % admin_auth['pass']
+        ]
+
+        cmd = ' '.join(test_args)
+
+        if '--key' not in cmd:
+            if 'ghostinspector_key' in cluster_config['secrets']:
+                gi_key = cluster_config['secrets']['ghostinspector_key']
+            elif 'GHOSTINSPECTOR_KEY' in os.environ:
+                gi_key = os.environ['GHOSTINSPECTOR_KEY']
+            else:
+                raise RuntimeError("ghostinspector api key must be provided or set "
+                                   "in secrets.json or ENV['GHOSTINSPECTOR_KEY']")
+            cmd += ' --key %s' % gi_key
+
+    with settings(
+            prefix('source .venv/bin/activate'),
+            hide('running'),
+            hide('warnings'),
+            warn_only=True):
+        local('mh --working-dir %s gi exec %s' % (os.getcwd(), cmd))

--- a/bin/setup
+++ b/bin/setup
@@ -19,6 +19,21 @@ echo
 
 bundle install --binstubs
 
+# Set up python virtualenv for mh-ui-testing
+if ! command -v virtualenv > /dev/null; then
+  echo "Please install virtualenv using easy_install or pip."
+  echo "On OSX (system python):"
+  echo "  sudo easy_install virtualenv"
+  echo "With pip:"
+  echo "  sudo pip install virtualenv"
+  exit 1;
+fi
+
+echo
+
+virtualenv .venv
+.venv/bin/pip install -U -r requirements.txt
+
 if [ ! -f "./secrets.json" ]; then
   cp templates/secrets_example.json ./secrets.json
   chmod 600 ./secrets.json

--- a/lib/tasks/docs/stack:instances:public_dns.txt
+++ b/lib/tasks/docs/stack:instances:public_dns.txt
@@ -1,0 +1,5 @@
+Output the public dns hostname for an instance
+
+Example:
+
+    ./bin/rake stack:instances:public_dns hostname=admin1

--- a/lib/tasks/stack.rake
+++ b/lib/tasks/stack.rake
@@ -120,6 +120,21 @@ namespace :stack do
     task start: ['cluster:configtest', 'cluster:config_sync_check'] do
       Cluster::Stack.start_all
     end
+    
+    desc Cluster::RakeDocs.new('stack:instances:public_dns').desc
+    task public_dns: ['cluster:configtest'] do
+      hostname = ENV['hostname'].to_s.strip
+      if hostname == ''
+        puts "Missing hostname arg"
+        exit 1
+      end
+      instance = Cluster::Instances.find_by_hostname(hostname)
+      if instance == nil
+        puts "#{hostname} does not exist"
+        exit 1
+      end
+      puts instance.public_dns
+    end
   end
 
   namespace :layers do

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# for optional ghost inspector test execution; see README.ui-testing.md                                                                                                
+mh-ui-testing==1.0.0   


### PR DESCRIPTION
Includes:
- create python virtualenv during ./bin/setup
- rake task for getting public dns for a node
- ./bin/mh_test shim script
