### PR TITLE
Alarm tooling improvements. Includes:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## TO BE RELEASED
 
+* Delete stack-level alarms when removing a cluster. Fix issue where alarms
+  were not being removed using the correct instance id.
+
 ## 1.4.0 - 5/10/2016
 
 * improved tooling to spin up local vagrant-backed all-in-one nodes. See

--- a/lib/cluster/sns.rb
+++ b/lib/cluster/sns.rb
@@ -5,40 +5,57 @@ module Cluster
       delete_subscriptions_for(topic_arn)
       delete_alarms_for_instances
       delete_rds_alarms
+      delete_stack_alarms
       sns_client.delete_topic(topic_arn: topic_arn)
     end
 
     private
+
+    def self.remove_alarms(to_remove)
+      if to_remove.any?
+        cloudwatch_client.delete_alarms(
+          alarm_names: to_remove.map { |alarm| alarm.alarm_name }
+        )
+      end
+    end
 
     def self.delete_rds_alarms
       to_remove = cloudwatch_client.describe_alarms.inject([]){ |memo, page| memo + page.metric_alarms }.find_all do |alarm|
         alarm.alarm_name.match(/^#{rds_name}/)
       end
 
-      if to_remove.any?
-        cloudwatch_client.delete_alarms(
-          alarm_names: to_remove.map { |alarm| alarm.alarm_name }
-        )
+      remove_alarms(to_remove)
+    end
+
+    def self.delete_stack_alarms
+      Cluster::Stack.with_existing_stack do |stack|
+        to_remove = []
+        stack_id = stack.stack_id
+        cloudwatch_client.describe_alarms.inject([]){ |memo, page| memo + page.metric_alarms }.each do |alarm|
+          alarm.dimensions.each do |dimension|
+            if dimension.name == 'StackId' && stack_id == dimension.value
+              to_remove << alarm
+            end
+          end
+        end
+
+        remove_alarms(to_remove)
       end
     end
 
     def self.delete_alarms_for_instances
-      opsworks_instance_ids = Cluster::Instances.find_existing.map { |i| i.instance_id }
+      ec2_instance_ids = Cluster::Instances.find_existing.map { |i| i.ec2_instance_id }
       to_remove = []
 
       cloudwatch_client.describe_alarms.inject([]){ |memo, page| memo + page.metric_alarms }.each do |alarm|
         alarm.dimensions.each do |dimension|
-          if dimension.name == 'InstanceId' && opsworks_instance_ids.include?(dimension.value)
+          if dimension.name == 'InstanceId' && ec2_instance_ids.include?(dimension.value)
             to_remove << alarm
           end
         end
       end
 
-      if to_remove.any?
-        cloudwatch_client.delete_alarms(
-          alarm_names: to_remove.map { |alarm| alarm.alarm_name }
-        )
-      end
+      remove_alarms(to_remove)
     end
 
     def self.delete_subscriptions_for(topic_arn, next_token = nil)


### PR DESCRIPTION
- Delete stack-level alarms when removing a cluster
- Minor refactor
- Use the ec2 instead of opsworks ID to remove "stuck" alarms on cluster
  delete
