### PR TITLE
apt package update tooling fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   rights (it should match `templates/example_group_inline_policy.json`). New
   clusters will automatically get these subscriptions. To update an existing
   cluster, switch into it and run `./bin/rake rds:create_event_subscriptions`
+* Fix `stack:commands:update_packages`, which will correctly apply only bug-
+  and security- fixes.
 
 ## 1.4.0 - 5/10/2016
 

--- a/lib/cluster/deployment.rb
+++ b/lib/cluster/deployment.rb
@@ -63,7 +63,7 @@ module Cluster
     end
 
     def self.update_dependencies
-      run_command_on_layers(command: 'dependencies')
+      run_command_on_layers(command: 'update_dependencies')
     end
 
     def self.update_chef_recipes

--- a/lib/tasks/docs/stack:commands:update_packages.txt
+++ b/lib/tasks/docs/stack:commands:update_packages.txt
@@ -1,5 +1,10 @@
 Update operating system packages
 
-Installs regular operating system and package updates. It should not lead to
-downtime, but it probably makes sense to be careful and test updates in a
-development or staging cluster.
+Installs regular operating system and package upgrades, not including kernel
+updates. It runs "apt-get update" and "apt-get upgrade -y" under the covers,
+which will install security and bugfix updates to packages. This should be
+done during a deploy window just in case.
+
+Recall that an LTS distribution will never increment a major or minor version
+of a package unless you run "apt-get dist-upgrade", which will install new
+versions of packages.


### PR DESCRIPTION
This fixes the "stack:commands:update_packages" command to correctly install
only bug- and security- fixes to ubuntu packages. This will not upgrade the
kernel.
