### PR TITLE
Allow for a couple of convenience defaults in `cluster:new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* Provide convenience defaults when executing `cluster:new`.
+
 ## 1.6.1 - 6/08/2016
 
 * Allow `install_updates_on_boot` to be configured when a layer is created or

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ and public key.  Following the example set in Step 1, it'd be "janesmith".
 It's easiest if your SSH user matches your default local unix username as
 the `stack:instances:ssh_to` rake task will work out of the box.
 
+A default git url can be provided by setting `MATTERHORN_GIT_URL` in your shell.
+
 ### Step 4 - Sanity check your cluster configuration
 
 We've implemented a set of sanity checks to ensure your cluster configuration

--- a/lib/cluster/config_creation_session.rb
+++ b/lib/cluster/config_creation_session.rb
@@ -5,13 +5,17 @@ module Cluster
 
     def choose_variant
       puts "Please choose the size of the cluster you'd like to deploy.\n\n"
+      default = Cluster::ConfigCreator::DEFAULT_VARIANT
       keys = []
       Cluster::ConfigCreator::VARIANTS.each do |key, variant|
         keys << key
         puts %Q|- #{key}: #{variant[:description]}|
       end
-      print %Q|\nOne of #{keys.join(', ')}: |
+      print %Q|\nOne of #{keys.join(', ')} [#{default}]: |
       variant_choice = STDIN.gets.strip.chomp.to_sym
+      if variant_choice.match(/^\s?$/)
+        variant_choice = default
+      end
       return choose_variant unless keys.include?(variant_choice)
 
       @variant = variant_choice
@@ -103,8 +107,13 @@ module Cluster
     end
 
     def get_git_url
-      print "\nThe git URL to the matterhorn repo, e.g. git@bitbucket.org. . .: "
+      default = ENV.fetch('MATTERHORN_GIT_URL', '')
+      print "\nThe git URL to the matterhorn repo, e.g. git@bitbucket.org [#{default}]: "
       git_url = STDIN.gets.strip.chomp
+
+      if git_url.match(/^\s?$/)
+        git_url = default
+      end
 
       unless git_url.match(/^git@|https:\/\//i)
         return get_git_url
@@ -114,7 +123,7 @@ module Cluster
     end
 
     def get_git_revision
-      print "\nThe branch, tag, or revision to deploy (hit enter to default to master): "
+      print "\nThe branch, tag, or revision to deploy [master]: "
       git_revision = STDIN.gets.strip.chomp
 
       if git_revision.match(/^\s?$/)

--- a/lib/cluster/config_creator.rb
+++ b/lib/cluster/config_creator.rb
@@ -1,5 +1,7 @@
 module Cluster
   class ConfigCreator
+    DEFAULT_VARIANT = :medium
+
     VARIANTS = {
       small: {
         template: './templates/cluster_config_default.json.erb',


### PR DESCRIPTION
Because I'm lazy and want to avoid all the clicky-clicky to get the matterhorn git url every time i create a new cluster.
