### PR TITLE
Add `custom_json` item for controlling chef log level.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* Add `custom_json` item for controlling chef log level.
+
 ## 1.6.2 - 6/24/2016
 
 * Provide convenience defaults when executing `cluster:new`.

--- a/README.md
+++ b/README.md
@@ -286,6 +286,9 @@ steps are:
 And then proceed normally - update your chef recipes, deploy, etc. The linked
 archive on s3 will be used for your custom recipes.
 
+To enable additional debug-level log output from chef, change the `chef_log_level` setting
+in your stack's custom json to "debug".
+
 ### Cluster switching
 
 The rake task `cluster:switch` looks for all configuration files stored in the

--- a/templates/cluster_config_default.json.erb
+++ b/templates/cluster_config_default.json.erb
@@ -24,6 +24,9 @@
     "default_ssh_key_name":"",
     "chef": {
       "custom_json": {
+        "opsworks": {
+          "chef_log_level": "info"
+        },
         "matterhorn_repo_root": "/opt/matterhorn",
         "matterhorn_log_directory": "/opt/matterhorn/log",
         "local_workspace_root": "/var/matterhorn-workspace",


### PR DESCRIPTION
This just adds the `custom_json` section for controlling chef log level. I got tired of googling how to do it.
