### PR TITLE
implements exponential backoff for resource waiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## TO BE RELEASED
 
+* Configure waiters to do "exponential backoff" when waiting for resources
+  to become available/deleted.
+
 ## 1.7.0 - 7/15/2016
 
 * Add `custom_json` item for controlling chef log level.

--- a/lib/cluster/waiters.rb
+++ b/lib/cluster/waiters.rb
@@ -140,9 +140,10 @@ module Cluster
 
       def apply_wait_options(w)
         w.tap do |w|
-          w.max_attempts = 600
-          w.delay = 5
-          w.before_wait do |attempts, response|
+          w.max_attempts = 60
+          w.delay = 0
+          w.before_wait do |attempts, response|0
+            sleep((attempts + 2) ** 2)
             print '.'
           end
         end


### PR DESCRIPTION
This is the first of what may be a few more changes to reduce the frequency of throttling errors being thrown by the AWS API. Anytime a `mh-opsworks` command creates or deletes a resource there is a "waiter" loop that polls the API to verify the status. We've been using a static 5s delay between these poll requests. This change implements a simple exponentially increasing delay in accordance with the AWS recommendations [here](http://docs.aws.amazon.com/sdk-for-ruby/latest//DeveloperGuide/aws-ruby-sdk-programming.html) and [here](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/query-api-troubleshooting.html).
