### PR TITLE
bump `retry_limit` setting on AWS client objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## TO BE RELEASED
 
+* Configure waiters to do "exponential backoff" when waiting for resources
+  to become available/deleted.
+
 ## 1.7.0 - 7/15/2016
 
 * Add `custom_json` item for controlling chef log level.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Configure waiters to do "exponential backoff" when waiting for resources
   to become available/deleted.
+* increase `retry_limit` on AWS client objects to alleviate failures due to 
+  API throttling errors
 
 ## 1.7.0 - 7/15/2016
 

--- a/lib/cluster/client_helpers.rb
+++ b/lib/cluster/client_helpers.rb
@@ -5,63 +5,72 @@ module Cluster
       def efs_client
         Aws::EFS::Client.new(
           region: config.parsed[:region],
-          credentials: config.credentials
+          credentials: config.credentials,
+          retry_limit: 6
         )
       end
 
       def sns_client
         Aws::SNS::Client.new(
           region: config.parsed[:region],
-          credentials: config.credentials
+          credentials: config.credentials,
+          retry_limit: 6
         )
       end
 
       def rds_client
         Aws::RDS::Client.new(
           region: config.parsed[:region],
-          credentials: config.credentials
+          credentials: config.credentials,
+          retry_limit: 6
         )
       end
 
       def cloudwatch_client
         Aws::CloudWatch::Client.new(
           region: config.parsed[:region],
-          credentials: config.credentials
+          credentials: config.credentials,
+          retry_limit: 6
         )
       end
 
       def s3_client
         Aws::S3::Client.new(
           region: 'us-east-1',
-          credentials: config.credentials
+          credentials: config.credentials,
+          retry_limit: 6
         )
       end
 
       def cloudformation_client
         Aws::CloudFormation::Client.new(
           region: config.parsed[:region],
-          credentials: config.credentials
+          credentials: config.credentials,
+          retry_limit: 6
         )
       end
 
       def iam_client
         Aws::IAM::Client.new(
           region: config.parsed[:region],
-          credentials: config.credentials
+          credentials: config.credentials,
+          retry_limit: 6
         )
       end
 
       def ec2_client
         Aws::EC2::Client.new(
           region: config.parsed[:region],
-          credentials: config.credentials
+          credentials: config.credentials,
+          retry_limit: 6
         )
       end
 
       def opsworks_client
         Aws::OpsWorks::Client.new(
           region: 'us-east-1',
-          credentials: config.credentials
+          credentials: config.credentials,
+          retry_limit: 6
         )
       end
     end

--- a/lib/cluster/waiters.rb
+++ b/lib/cluster/waiters.rb
@@ -140,9 +140,10 @@ module Cluster
 
       def apply_wait_options(w)
         w.tap do |w|
-          w.max_attempts = 600
-          w.delay = 5
-          w.before_wait do |attempts, response|
+          w.max_attempts = 60
+          w.delay = 0
+          w.before_wait do |attempts, response|0
+            sleep((attempts + 2) ** 2)
             print '.'
           end
         end


### PR DESCRIPTION
This will hopefully alleviate some of the API throttling errors that cause commands to abort. The default `retry_limit` is 3; this bumps it to 6. The client waits an exponentially increasing amount of time between retries. 
