### PR TITLE
bin/setup annoyances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## TO BE RELEASED
 
 * tag provisioned s3 buckets with the opsworks stack name
+* Fix a couple of issues that resulted in modifications to files as a
+  side-effect of running `bin/setup`.
 
 ## 1.7.1 - 7/20/2016
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,3 @@ DEPENDENCIES
   rspec-expectations (~> 3.3.0)
   rspec-mocks (~> 3.3.0)
   simplecov
-
-BUNDLED WITH
-   1.11.2

--- a/bin/aws.rb
+++ b/bin/aws.rb
@@ -6,11 +6,11 @@
 # this file is here to facilitate running it.
 #
 
-require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require "rubygems"
-require "bundler/setup"
+require 'rubygems'
+require 'bundler/setup'
 
-load Gem.bin_path("aws-sdk-core", "aws.rb")
+load Gem.bin_path('aws-sdk-core', 'aws.rb')

--- a/bin/bundler
+++ b/bin/bundler
@@ -6,11 +6,11 @@
 # this file is here to facilitate running it.
 #
 
-require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require "rubygems"
-require "bundler/setup"
+require 'rubygems'
+require 'bundler/setup'
 
-load Gem.bin_path("bundler", "bundler")
+load Gem.bin_path('bundler', 'bundler')

--- a/bin/coderay
+++ b/bin/coderay
@@ -6,11 +6,11 @@
 # this file is here to facilitate running it.
 #
 
-require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require "rubygems"
-require "bundler/setup"
+require 'rubygems'
+require 'bundler/setup'
 
-load Gem.bin_path("coderay", "coderay")
+load Gem.bin_path('coderay', 'coderay')

--- a/bin/erubis
+++ b/bin/erubis
@@ -6,11 +6,11 @@
 # this file is here to facilitate running it.
 #
 
-require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require "rubygems"
-require "bundler/setup"
+require 'rubygems'
+require 'bundler/setup'
 
-load Gem.bin_path("erubis", "erubis")
+load Gem.bin_path('erubis', 'erubis')

--- a/bin/htmldiff
+++ b/bin/htmldiff
@@ -6,11 +6,11 @@
 # this file is here to facilitate running it.
 #
 
-require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require "rubygems"
-require "bundler/setup"
+require 'rubygems'
+require 'bundler/setup'
 
-load Gem.bin_path("diff-lcs", "htmldiff")
+load Gem.bin_path('diff-lcs', 'htmldiff')

--- a/bin/ldiff
+++ b/bin/ldiff
@@ -6,11 +6,11 @@
 # this file is here to facilitate running it.
 #
 
-require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require "rubygems"
-require "bundler/setup"
+require 'rubygems'
+require 'bundler/setup'
 
-load Gem.bin_path("diff-lcs", "ldiff")
+load Gem.bin_path('diff-lcs', 'ldiff')

--- a/bin/pry
+++ b/bin/pry
@@ -6,11 +6,11 @@
 # this file is here to facilitate running it.
 #
 
-require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require "rubygems"
-require "bundler/setup"
+require 'rubygems'
+require 'bundler/setup'
 
-load Gem.bin_path("pry", "pry")
+load Gem.bin_path('pry', 'pry')

--- a/bin/rake
+++ b/bin/rake
@@ -6,11 +6,11 @@
 # this file is here to facilitate running it.
 #
 
-require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require "rubygems"
-require "bundler/setup"
+require 'rubygems'
+require 'bundler/setup'
 
-load Gem.bin_path("rake", "rake")
+load Gem.bin_path('rake', 'rake')

--- a/bin/rspec
+++ b/bin/rspec
@@ -6,11 +6,11 @@
 # this file is here to facilitate running it.
 #
 
-require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require "rubygems"
-require "bundler/setup"
+require 'rubygems'
+require 'bundler/setup'
 
-load Gem.bin_path("rspec-core", "rspec")
+load Gem.bin_path('rspec-core', 'rspec')


### PR DESCRIPTION
 The main thing that `bin/setup` does is execute `bundler install --binstubs`. There are two annoying side-effects of running this that interfere with git version control that this PR fixes.
1. `bundler install` rewrites `Gemfile.lock` and removes the "BUNDLED WITH..." indicator. This was something that doesn't need to be included in a git-controlled file as, theoretically users could have different versions of bundler.
2. The `--binstubs` flag tells bundler to generate "binstub" files. These are scripts that wrap the execution of commands included in many of the gem dependencies listed in the `Gemfile`. At some point bundler decided that it should generate these using only single-quoted strings, whereas our repo has them committed using double-quoted strings.

The result is that when you run `bin/setup` you end up with a dozen "changed" files in your local clone that could unintentionally get committed back as part of an unrelated change.
