### PR TITLE
removed unnecessary `/var/matterhorn-workspace` volume definition from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Fix a couple of issues that resulted in modifications to files as a
   side-effect of running `bin/setup`.
 * prompt user to consider using a local vagrant cluster
+* removed unnecessary `/var/matterhorn-workspace` volume definition from
+  workers layer config in all cluster config templates.
 
 ## 1.7.1 - 7/20/2016
 

--- a/templates/cluster_config_ami_builder.json.erb
+++ b/templates/cluster_config_ami_builder.json.erb
@@ -172,14 +172,7 @@
           "deploy": [ ],
           "shutdown": [ ]
         },
-        "volume_configurations": [
-          {
-            "mount_point": "/var/matterhorn-workspace",
-            "number_of_disks": 1,
-            "size": "<%= matterhorn_workspace_size %>",
-            "volume_type": "gp2"
-          }
-        ],
+        "volume_configurations": [ ],
         "instances": {
           "_fake_number_of_instances": "<%= workers_instance_count %>",
           "number_of_instances": 0,

--- a/templates/cluster_config_default.json.erb
+++ b/templates/cluster_config_default.json.erb
@@ -191,12 +191,6 @@
         },
         "volume_configurations": [
           {
-            "mount_point": "/var/matterhorn-workspace",
-            "number_of_disks": 1,
-            "size": "<%= matterhorn_workspace_size %>",
-            "volume_type": "gp2"
-          },
-          {
             "mount_point": "/opt/matterhorn",
             "number_of_disks": 1,
             "size": "<%= matterhorn_root_size %>",

--- a/templates/cluster_config_efs.json.erb
+++ b/templates/cluster_config_efs.json.erb
@@ -150,12 +150,6 @@
         },
         "volume_configurations": [
           {
-            "mount_point": "/var/matterhorn-workspace",
-            "number_of_disks": 1,
-            "size": "<%= matterhorn_workspace_size %>",
-            "volume_type": "gp2"
-          },
-          {
             "mount_point": "/opt/matterhorn",
             "number_of_disks": 1,
             "size": "<%= matterhorn_root_size %>",

--- a/templates/cluster_config_zadara.json.erb
+++ b/templates/cluster_config_zadara.json.erb
@@ -148,12 +148,6 @@
         },
         "volume_configurations": [
           {
-            "mount_point": "/var/matterhorn-workspace",
-            "number_of_disks": 1,
-            "size": "<%= matterhorn_workspace_size %>",
-            "volume_type": "gp2"
-          },
-          {
             "mount_point": "/opt/matterhorn",
             "number_of_disks": 1,
             "size": "<%= matterhorn_root_size %>",


### PR DESCRIPTION
workers layer config in all cluster config templates.
