### PR TITLE
add the queued jobs metric recipe to the ganglia layer's setup list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* add the `install-job-queued-metric` recipe to the Ganglia layer's setup list
+
 ## 1.8.0 - 8/11/2016
 
 * tag provisioned s3 buckets with the opsworks stack name

--- a/templates/cluster_config_default.json.erb
+++ b/templates/cluster_config_default.json.erb
@@ -282,6 +282,7 @@
             "mh-opsworks-recipes::install-utils",
             "mh-opsworks-recipes::enable-postfix-smarthost",
             "mh-opsworks-recipes::install-custom-metrics",
+            "mh-opsworks-recipes::install-job-queued-metrics",
             "mh-opsworks-recipes::create-alerts-from-opsworks-metrics",
             "mh-opsworks-recipes::enable-enhanced-networking",
             "mh-opsworks-recipes::install-moscaler",

--- a/templates/cluster_config_efs.json.erb
+++ b/templates/cluster_config_efs.json.erb
@@ -241,6 +241,7 @@
             "mh-opsworks-recipes::install-utils",
             "mh-opsworks-recipes::enable-postfix-smarthost",
             "mh-opsworks-recipes::install-custom-metrics",
+            "mh-opsworks-recipes::install-job-queued-metrics",
             "mh-opsworks-recipes::create-alerts-from-opsworks-metrics",
             "mh-opsworks-recipes::enable-enhanced-networking",
             "mh-opsworks-recipes::install-moscaler",

--- a/templates/cluster_config_zadara.json.erb
+++ b/templates/cluster_config_zadara.json.erb
@@ -239,6 +239,7 @@
             "mh-opsworks-recipes::install-utils",
             "mh-opsworks-recipes::enable-postfix-smarthost",
             "mh-opsworks-recipes::install-custom-metrics",
+            "mh-opsworks-recipes::install-job-queued-metrics",
             "mh-opsworks-recipes::create-alerts-from-opsworks-metrics",
             "mh-opsworks-recipes::enable-enhanced-networking",
             "mh-opsworks-recipes::install-moscaler",


### PR DESCRIPTION
Correcting an oversight on my part. This recipe was added to prod's cluster config at the point of the last mo-scaler release, but didn't make it into the templates for making new clusters.
