### PR TITLE
don't use bundler's `--binstubs` flag in `bin/setup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* don't use the `--binstubs` flag in `bin/setup`
+
 ## 1.8.1 - 9/08/2016
 
 * add the `install-job-queued-metric` recipe to the Ganglia layer's setup list

--- a/bin/setup
+++ b/bin/setup
@@ -17,7 +17,7 @@ fi
 
 echo
 
-bundle install --binstubs
+bundle install
 
 if [ ! -f "./secrets.json" ]; then
   cp templates/secrets_example.json ./secrets.json


### PR DESCRIPTION
This `--binstubs` flag is killing me and it must go!

The purpose is to have bundler generate any wrapper scripts that a gem might need in the `./bin` directory, e.g., `rake` or `pry`. But we have all those script pre-generated and checked into version control, and depending on the user's environment, bundler is regenerating the scripts with single quotes replaced with double quotes (or vice versa), and making git think there are local changes.

If a developer ever updates to a new version of a gem in `Gemfile` they can generate the binstub script(s) and check them in along with the other changes.
