### PR TITLE
matt-1108-tag: custom tagging as rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,6 +760,45 @@ Fortunately error messages are fairly clear when a resource limit is hit,
 either in the shell output of mh-opsworks or in the aws web cloudformation (or
 other) UIs.
 
+### Custom Tags
+
+When you create a new cluster you are prompted to input a value for the
+`Project` tag, the default value is `MH`. You can also do `rake cluster:edit`
+to add or change tags in the custom json section.
+
+```
+{
+  "stack": {
+    "chef": {
+      "custom_json": {
+        ...
+        "aws_custom_tags": [
+            {"key": "OU", "value": "DE"},
+            {"key": "Project", "value": "MH"}
+        ],
+      },
+
+      ...
+
+      }
+    }
+  }
+}
+
+```
+
+Tags are applied to VPCs, RDS instance, and S3 buckets, when you do `rake
+admin:cluster:init` (when these resources are created). EC2 instances and EBS
+volumes have tags applied every time you do `rake stack:instances:start`. Note
+that if you start the instance for the first time from the AWS Opsworks
+console, the instance will not be tagged.
+
+Tags can also be applied to the cluster via command `rake admin:cluster:tag`.
+This will tag VPCs, RDS instance, S3 buckets, EC2 instances, and EBS volumes.
+Note that applying tags will update or create new tags, but will not remove existing
+tags.
+
+
 ## TODO
 
 * Automate cloudfront distribution creation

--- a/Rakefile
+++ b/Rakefile
@@ -68,6 +68,22 @@ namespace :admin do
       puts 'deleting configuration files'
       Cluster::RemoteConfig.new.delete
     end
+
+    desc Cluster::RakeDocs.new('admin:cluster:tag').desc
+    task tag: ['cluster:configtest', 'cluster:config_sync_check'] do
+      puts 'tagging instances and volumes'
+      Cluster::Instances.create_custom_tags
+
+      puts 'tagging vpc'
+      Cluster::VPC.create_custom_tags
+
+      puts 'tagging rds instance'
+      Cluster::RDS.create_custom_tags
+
+      puts 'tagging s3 buckets'
+      Cluster::S3Bucket.create_custom_tags(Cluster::Base.distribution_bucket_name)
+      Cluster::S3Bucket.create_custom_tags(Cluster::Base.s3_file_archive_bucket_name)
+    end
   end
 
   namespace :users do

--- a/lib/cluster/config_creation_session.rb
+++ b/lib/cluster/config_creation_session.rb
@@ -25,11 +25,8 @@ module Cluster
       print "\nWhat value for Project Tag? [MH]: "
       project_tag = STDIN.gets.strip.chomp
 
-      #if project_tag.match(/^\s?/)
-      #  @project_tag = "MH"
-      #else
-      #  @project_tag = project_tag
-      #end
+      # the default is set in the template mainly because, in tests, this isn't
+      # run and project_tag doesnt' get a default value
       @project_tag = project_tag
     end
 

--- a/lib/cluster/config_creation_session.rb
+++ b/lib/cluster/config_creation_session.rb
@@ -1,7 +1,7 @@
 module Cluster
   class ConfigCreationSession
     attr_accessor :variant, :name, :cidr_block_root, :git_url, :git_revision,
-      :export_root, :nfs_server_host, :primary_az, :secondary_az
+      :export_root, :nfs_server_host, :primary_az, :secondary_az, :project_tag
 
     def choose_variant
       puts "\nPlease choose the size of the cluster you'd like to deploy.\n\n"
@@ -19,6 +19,18 @@ module Cluster
       return choose_variant unless keys.include?(variant_choice)
 
       @variant = variant_choice
+    end
+
+    def get_project_tag
+      print "\nWhat value for Project Tag? [MH]: "
+      project_tag = STDIN.gets.strip.chomp
+
+      #if project_tag.match(/^\s?/)
+      #  @project_tag = "MH"
+      #else
+      #  @project_tag = project_tag
+      #end
+      @project_tag = project_tag
     end
 
     def zadara_variant?

--- a/lib/cluster/config_creator.rb
+++ b/lib/cluster/config_creator.rb
@@ -247,6 +247,7 @@ module Cluster
       base_secrets = %Q|, #{get_base_secrets_content}|
 
       all_attributes = attributes.merge(variant_attributes).
+        merge(project_tag).
         merge(base_secrets_content: base_secrets).
         merge(database_user_info).
         merge(s3_distribution_bucket_name_from(attributes[:name])).
@@ -256,6 +257,17 @@ module Cluster
     end
 
     private
+
+    def project_tag
+      if attributes[:project_tag].nil? || attributes[:project_tag].empty?
+        tag = "MH"
+      else
+        tag = attributes[:project_tag]
+      end
+      {
+        project_tag: tag
+      }
+    end
 
     def s3_distribution_bucket_name_from(name)
       {

--- a/lib/cluster/configuration_helpers.rb
+++ b/lib/cluster/configuration_helpers.rb
@@ -84,6 +84,10 @@ module Cluster
           layer[:shortname] == layer_shortname
         end.fetch(:instances, {})
       end
+
+      def stack_custom_tags
+        stack_custom_json[:aws_custom_tags] || []
+      end
     end
 
     def self.included(base)

--- a/lib/cluster/instances.rb
+++ b/lib/cluster/instances.rb
@@ -89,5 +89,27 @@ module Cluster
         end
       end
     end
+
+    def self.create_custom_tags
+      custom_tags = stack_custom_json[:aws_custom_tags] || []
+      if custom_tags.empty?
+        return
+      end
+
+      stack = Stack.find_existing
+      resource_ids = []
+      resp = opsworks_client.describe_volumes({stack_id: stack.stack_id})
+      resp.volumes.each do |volume|
+        resource_ids.push(volume.ec2_volume_id)
+      end
+      find_existing.each do |instance|
+        resource_ids.push(instance.ec2_instance_id)
+      end
+      ec2_client.create_tags({
+          dry_run: false,
+          resources: resource_ids,
+          tags: custom_tags
+      })
+    end
   end
 end

--- a/lib/cluster/instances.rb
+++ b/lib/cluster/instances.rb
@@ -91,24 +91,19 @@ module Cluster
     end
 
     def self.create_custom_tags
-      custom_tags = stack_custom_json[:aws_custom_tags] || []
-      if custom_tags.empty?
+      if stack_custom_tags.empty?
         return
       end
 
-      stack = Stack.find_existing
-      resource_ids = []
-      resp = opsworks_client.describe_volumes({stack_id: stack.stack_id})
-      resp.volumes.each do |volume|
-        resource_ids.push(volume.ec2_volume_id)
-      end
+      resource_ids = Stack.find_volume_ids
       find_existing.each do |instance|
         resource_ids.push(instance.ec2_instance_id)
       end
+
       ec2_client.create_tags({
           dry_run: false,
           resources: resource_ids,
-          tags: custom_tags
+          tags: stack_custom_tags
       })
     end
   end

--- a/lib/cluster/rds.rb
+++ b/lib/cluster/rds.rb
@@ -56,7 +56,7 @@ module Cluster
         tags: [ {
           key: "opsworks:stack",
           value: stack_config[:name],
-        } ].concat(stack_custom_json[:aws_custom_tags]),
+        } ].concat(stack_custom_tags),
         vpc_security_group_ids: [ sg_group_id ],
 
         auto_minor_version_upgrade: false,
@@ -93,14 +93,13 @@ module Cluster
     end
 
     def self.create_custom_tags
-      custom_tags = stack_custom_json[:aws_custom_tags] || []
-      if custom_tags.empty?
+      if stack_custom_tags.empty?
         return
       end
 
       rds_client.add_tags_to_resource({
         resource_name: rds_db_instance_arn,
-        tags: custom_tags
+        tags: stack_custom_tags
       })
     end
   end

--- a/lib/cluster/rds.rb
+++ b/lib/cluster/rds.rb
@@ -56,7 +56,7 @@ module Cluster
         tags: [ {
           key: "opsworks:stack",
           value: stack_config[:name],
-        } ],
+        } ].concat(stack_custom_json[:aws_custom_tags]),
         vpc_security_group_ids: [ sg_group_id ],
 
         auto_minor_version_upgrade: false,
@@ -90,6 +90,18 @@ module Cluster
 
     def self.construct_instance(rds)
       Aws::RDS::DBInstance.new(rds.db_instance_identifier, client: rds_client)
+    end
+
+    def self.create_custom_tags
+      custom_tags = stack_custom_json[:aws_custom_tags] || []
+      if custom_tags.empty?
+        return
+      end
+
+      rds_client.add_tags_to_resource({
+        resource_name: rds_db_instance_arn,
+        tags: custom_tags
+      })
     end
   end
 end

--- a/lib/cluster/s3_bucket.rb
+++ b/lib/cluster/s3_bucket.rb
@@ -33,7 +33,7 @@ module Cluster
               key: 'opsworks:stack',
               value: stack_config[:name]
             }
-          ].concat(stack_custom_json[:aws_custom_tags] || [])
+          ].concat(stack_custom_tags)
         }
       )
 
@@ -52,14 +52,13 @@ module Cluster
     end
 
     def self.create_custom_tags(name)
-      custom_tags = stack_custom_json[:aws_custom_tags] || []
-      if custom_tags.empty?
+      if stack_custom_tags.empty?
         return
       end
 
       s3_client.put_bucket_tagging({
         bucket: "#{name}",
-        tagging: {tag_set: custom_tags},
+        tagging: {tag_set: stack_custom_tags},
         use_accelerate_endpoint: false
       })
 

--- a/lib/cluster/s3_bucket.rb
+++ b/lib/cluster/s3_bucket.rb
@@ -33,7 +33,7 @@ module Cluster
               key: 'opsworks:stack',
               value: stack_config[:name]
             }
-          ]
+          ].concat(stack_custom_json[:aws_custom_tags] || [])
         }
       )
 
@@ -49,6 +49,20 @@ module Cluster
 
     def self.construct_bucket(name)
       Aws::S3::Bucket.new(name, client: s3_client)
+    end
+
+    def self.create_custom_tags(name)
+      custom_tags = stack_custom_json[:aws_custom_tags] || []
+      if custom_tags.empty?
+        return
+      end
+
+      s3_client.put_bucket_tagging({
+        bucket: "#{name}",
+        tagging: {tag_set: custom_tags},
+        use_accelerate_endpoint: false
+      })
+
     end
   end
 end

--- a/lib/cluster/stack.rb
+++ b/lib/cluster/stack.rb
@@ -207,5 +207,16 @@ module Cluster
     def self.construct_instance(stack_id)
       Aws::OpsWorks::Stack.new(stack_id, client: opsworks_client)
     end
+
+    def self.find_volume_ids
+      volume_ids = []
+      stack = find_existing
+      resp = opsworks_client.describe_volumes({stack_id: stack.stack_id})
+      resp.volumes.each do |volume|
+        volume_ids.push(volume.ec2_volume_id)
+      end
+
+      volume_ids
+    end
   end
 end

--- a/lib/cluster/vpc.rb
+++ b/lib/cluster/vpc.rb
@@ -104,7 +104,7 @@ module Cluster
             key: 'opsworks:stack',
             value: stack_config[:name]
           }
-        ]
+        ].concat(stack_custom_json[:aws_custom_tags])
       }
     end
 
@@ -150,6 +150,19 @@ module Cluster
       if name_tag
         name_tag.value
       end
+    end
+
+    def self.create_custom_tags
+      custom_tags = stack_custom_json[:aws_custom_tags] || []
+      if custom_tags.empty?
+        return
+      end
+
+      vpc = find_existing
+      vpc.create_tags({
+          dry_run: false,
+          tags: custom_tags
+      })
     end
   end
 end

--- a/lib/cluster/vpc.rb
+++ b/lib/cluster/vpc.rb
@@ -104,7 +104,7 @@ module Cluster
             key: 'opsworks:stack',
             value: stack_config[:name]
           }
-        ].concat(stack_custom_json[:aws_custom_tags])
+        ].concat(stack_custom_tags)
       }
     end
 
@@ -153,15 +153,14 @@ module Cluster
     end
 
     def self.create_custom_tags
-      custom_tags = stack_custom_json[:aws_custom_tags] || []
-      if custom_tags.empty?
+      if stack_custom_tags.empty?
         return
       end
 
       vpc = find_existing
       vpc.create_tags({
           dry_run: false,
-          tags: custom_tags
+          tags: stack_custom_tags
       })
     end
   end

--- a/lib/tasks/cluster.rake
+++ b/lib/tasks/cluster.rake
@@ -176,6 +176,7 @@ namespace :cluster do
   task :new do
     session = Cluster::ConfigCreationSession.new
     session.local_vs_opsworks
+    session.get_project_tag
     session.choose_variant
     session.get_cluster_name
     session.get_git_url
@@ -191,6 +192,7 @@ namespace :cluster do
     config_file = Cluster::RemoteConfig.create(
       name: session.name,
       variant: session.variant,
+      project_tag: session.project_tag,
       cidr_block_root: session.cidr_block_root,
       app_git_url: session.git_url,
       app_git_revision: session.git_revision,

--- a/lib/tasks/docs/admin:cluster:tag.txt
+++ b/lib/tasks/docs/admin:cluster:tag.txt
@@ -1,0 +1,6 @@
+Tags resources in cluster with custom tags
+
+Resources include instances, their volumes, rds instances, s3 buckets,
+and vpcs.
+
+Custom tags are defined in the custom_json in the cluster config.

--- a/lib/tasks/docs/stack:instances:start.txt
+++ b/lib/tasks/docs/stack:instances:start.txt
@@ -10,6 +10,8 @@ EBS volumes is relatively expensive.
 
 Subsequent starts go much faster, maybe 10 to 15 minutes.
 
+Custom tags are created or updated when starting instances via this command.
+
 SEE ALSO:
 
 admin:cluster:init, stack:instances:stop

--- a/lib/tasks/stack.rake
+++ b/lib/tasks/stack.rake
@@ -119,6 +119,7 @@ namespace :stack do
     desc Cluster::RakeDocs.new('stack:instances:start').desc
     task start: ['cluster:configtest', 'cluster:config_sync_check'] do
       Cluster::Stack.start_all
+      Cluster::Instances.create_custom_tags
     end
   end
 

--- a/templates/cluster_config_default.json.erb
+++ b/templates/cluster_config_default.json.erb
@@ -27,6 +27,10 @@
         "opsworks": {
           "chef_log_level": "info"
         },
+        "aws_custom_tags": [
+            {"key": "OU", "value": "DE"},
+            {"key": "Project", "value": "<%= project_tag %>"}
+        ],
         "matterhorn_repo_root": "/opt/matterhorn",
         "matterhorn_log_directory": "/opt/matterhorn/log",
         "local_workspace_root": "/var/matterhorn-workspace",

--- a/templates/cluster_config_efs.json.erb
+++ b/templates/cluster_config_efs.json.erb
@@ -24,6 +24,10 @@
     "default_ssh_key_name":"",
     "chef": {
       "custom_json": {
+        "aws_custom_tags": [
+            { "key": "OU", "value": "DE },
+            { "key": "Project", "value": "<%= project_tag %>" }
+        ],
         "matterhorn_repo_root": "/opt/matterhorn",
         "matterhorn_log_directory": "/opt/matterhorn/log",
         "local_workspace_root": "/var/matterhorn-workspace",

--- a/templates/cluster_config_zadara.json.erb
+++ b/templates/cluster_config_zadara.json.erb
@@ -24,6 +24,10 @@
     "default_ssh_key_name":"",
     "chef": {
       "custom_json": {
+        "aws_custom_tags": [
+            { "key": "OU", "value": "DE },
+            { "key": "Project", "value": "<%= project_tag %>" }
+        ],
         "matterhorn_repo_root": "/opt/matterhorn",
         "matterhorn_log_directory": "/opt/matterhorn/log",
         "local_workspace_root": "/var/matterhorn-workspace",


### PR DESCRIPTION
- add new rake task `admin:cluster:tag` that tags instances,
  their volumes, rds instance, s3 buckets, and vpc
- include tagging of vpc, rds, and s3 in `admin:cluster:init`
- include tagging of instances in `stack:instances:start`
