### PR TITLE
mi-58-tag: tag root devices and nat instance

### DIFF
--- a/lib/cluster/instances.rb
+++ b/lib/cluster/instances.rb
@@ -96,8 +96,12 @@ module Cluster
       end
 
       vpc = VPC.find_existing
-      resource_ids = []
+
+      # ec2_client doesn't bring detached volumes, have to use opsworks_client
+      resource_ids = [].concat(Stack.find_volume_ids)
+
       # opsworks_client doesn't bring the NAT instance, have to use ec2_client
+      # note that there will be duplicated volumes in the array
       resp = ec2_client.describe_instances({
         dry_run: false,
         filters: [

--- a/lib/cluster/stack.rb
+++ b/lib/cluster/stack.rb
@@ -207,5 +207,15 @@ module Cluster
     def self.construct_instance(stack_id)
       Aws::OpsWorks::Stack.new(stack_id, client: opsworks_client)
     end
+
+    def self.find_volume_ids
+      volume_ids = []
+      stack = find_existing
+      resp = opsworks_client.describe_volumes({stack_id: stack.stack_id})
+      resp.volumes.each do |volume|
+        volume_ids.push(volume.ec2_volume_id)
+      end
+      volume_ids
+    end
   end
 end

--- a/lib/cluster/stack.rb
+++ b/lib/cluster/stack.rb
@@ -207,16 +207,5 @@ module Cluster
     def self.construct_instance(stack_id)
       Aws::OpsWorks::Stack.new(stack_id, client: opsworks_client)
     end
-
-    def self.find_volume_ids
-      volume_ids = []
-      stack = find_existing
-      resp = opsworks_client.describe_volumes({stack_id: stack.stack_id})
-      resp.volumes.each do |volume|
-        volume_ids.push(volume.ec2_volume_id)
-      end
-
-      volume_ids
-    end
   end
 end


### PR DESCRIPTION
- use ec2_client to get volume_ids instead of opsworks_client (doesn't return the root volumes)
- tag nat instance and volumes
