### PR TITLE
Add prompt for including analytics node in `cluster:new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* Make it easier to add an analytics node via `cluster:new`
+
 ## 1.10.0 - 10/19/2016
 
 * don't use the `--binstubs` flag in `bin/setup`

--- a/lib/cluster/config_creation_session.rb
+++ b/lib/cluster/config_creation_session.rb
@@ -1,7 +1,8 @@
 module Cluster
   class ConfigCreationSession
     attr_accessor :variant, :name, :cidr_block_root, :git_url, :git_revision,
-      :export_root, :nfs_server_host, :primary_az, :secondary_az, :project_tag
+      :export_root, :nfs_server_host, :primary_az, :secondary_az, :project_tag,
+      :include_analytics
 
     def choose_variant
       puts "\nPlease choose the size of the cluster you'd like to deploy.\n\n"
@@ -149,6 +150,15 @@ module Cluster
       if local_vs_opsworks.downcase == 'y'
         print "Great! You just saved some money!\n"
         exit 0
+      end
+    end
+
+    def analytics_node
+      print "\nWould you like an analytics node? [y/N]: "
+      include_analytics = STDIN.gets.strip.chomp
+
+      if include_analytics.downcase == 'y'
+        @include_analytics = true
       end
     end
 

--- a/lib/cluster/config_creator.rb
+++ b/lib/cluster/config_creator.rb
@@ -25,6 +25,9 @@ module Cluster
         ganglia_instance_type: 't2.medium',
         ganglia_disk_size: '10',
 
+        analytics_instance_type: 't2.large',
+        analytics_disk_size: '20',
+
         matterhorn_root_size: '20',
         root_device_size: '8',
         matterhorn_workspace_size: '50'
@@ -51,6 +54,9 @@ module Cluster
 
         ganglia_instance_type: 't2.medium',
         ganglia_disk_size: '20',
+
+        analytics_instance_type: 'm4.large',
+        analytics_disk_size: '50',
 
         matterhorn_root_size: '20',
         root_device_size: '8',
@@ -79,6 +85,9 @@ module Cluster
         ganglia_instance_type: 'c4.large',
         ganglia_disk_size: '100',
 
+        analytics_instance_type: 'm4.xlarge',
+        analytics_disk_size: '500',
+
         matterhorn_root_size: '50',
         root_device_size: '16',
         matterhorn_workspace_size: '250'
@@ -103,6 +112,9 @@ module Cluster
         ganglia_instance_type: 't2.medium',
         ganglia_disk_size: '20',
 
+        analytics_instance_type: 'm4.large',
+        analytics_disk_size: '50',
+
         matterhorn_root_size: '20',
         root_device_size: '8',
         matterhorn_workspace_size: '50'
@@ -126,6 +138,9 @@ module Cluster
 
         ganglia_instance_type: 'c4.large',
         ganglia_disk_size: '100',
+
+        analytics_instance_type: 'm4.xlarge',
+        analytics_disk_size: '500',
 
         matterhorn_root_size: '50',
         root_device_size: '16',
@@ -251,12 +266,19 @@ module Cluster
         merge(base_secrets_content: base_secrets).
         merge(database_user_info).
         merge(s3_distribution_bucket_name_from(attributes[:name])).
-        merge(s3_file_archive_bucket_name_from(attributes[:name]))
+        merge(s3_file_archive_bucket_name_from(attributes[:name])).
+        merge(analytics_layer_content)
 
       erb.result(all_attributes)
     end
 
     private
+
+    def analytics_layer_content
+      {
+        analytics_layer_template: File.read('templates/analytics_layer.json.erb')
+      }
+    end
 
     def project_tag
       if attributes[:project_tag].nil? || attributes[:project_tag].empty?

--- a/lib/tasks/cluster.rake
+++ b/lib/tasks/cluster.rake
@@ -178,6 +178,7 @@ namespace :cluster do
     session.local_vs_opsworks
     session.get_project_tag
     session.choose_variant
+    session.analytics_node
     session.get_cluster_name
     session.get_git_url
     session.get_git_revision
@@ -200,7 +201,8 @@ namespace :cluster do
       nfs_server_host: session.nfs_server_host,
       primary_az: session.primary_az,
       secondary_az: session.secondary_az,
-      default_users: JSON.pretty_generate(session.compute_default_users)
+      default_users: JSON.pretty_generate(session.compute_default_users),
+      include_analytics: session.include_analytics
     )
     rc_file = Cluster::RcFileSwitcher.new(config_file: config_file)
     rc_file.write

--- a/spec/lib/cluster/config_creator_spec.rb
+++ b/spec/lib/cluster/config_creator_spec.rb
@@ -74,7 +74,8 @@ describe Cluster::ConfigCreator do
       app_git_revision: app_git_revision,
       default_users: default_users,
       primary_az: primary_az,
-      secondary_az: secondary_az
+      secondary_az: secondary_az,
+      include_analytics: true
     }
   end
 end

--- a/spec/support/cluster_creation_helpers.rb
+++ b/spec/support/cluster_creation_helpers.rb
@@ -7,7 +7,8 @@ module ClusterCreationHelpers
       app_git_revision: '',
       default_users: '',
       primary_az: 'us-east-1a',
-      secondary_az: 'us-east-1d'
+      secondary_az: 'us-east-1d',
+      include_analytics: true
     }
   end
 end

--- a/templates/analytics_layer.json.erb
+++ b/templates/analytics_layer.json.erb
@@ -1,0 +1,48 @@
+{
+  "name": "Analytics",
+  "shortname": "analytics",
+  "enable_auto_healing": true,
+  "install_updates_on_boot": true,
+  "type": "custom",
+  "auto_assign_elastic_ips": true,
+  "auto_assign_public_ips": true,
+  "use_ebs_optimized_instances": true,
+  "custom_recipes": {
+    "setup": [
+      "mh-opsworks-recipes::set-timezone",
+      "mh-opsworks-recipes::fix-raid-mapping",
+      "mh-opsworks-recipes::set-bash-as-default-shell",
+      "mh-opsworks-recipes::install-utils",
+      "mh-opsworks-recipes::install-mh-base-packages",
+      "mh-opsworks-recipes::enable-postfix-smarthost",
+      "mh-opsworks-recipes::install-custom-metrics",
+      "mh-opsworks-recipes::create-alerts-from-opsworks-metrics",
+      "mh-opsworks-recipes::enable-enhanced-networking",
+      "mh-opsworks-recipes::install-cwlogs",
+      "mh-opsworks-recipes::install-elasticsearch",
+      "mh-opsworks-recipes::install-ua-harvester",
+      "mh-opsworks-recipes::install-logstash-kibana",
+      "mh-opsworks-recipes::clean-up-package-cache"
+    ],
+    "configure": [
+      "mh-opsworks-recipes::configure-ua-harvester"
+    ],
+    "shutdown": [
+      "mh-opsworks-recipes::remove-alarms"
+    ]
+  },
+  "volume_configurations": [
+    {
+      "mount_point": "/vol/elasticsearch_data",
+      "number_of_disks": 1,
+      "size": "<%= analytics_disk_size %>",
+      "volume_type": "gp2"
+    }
+  ],
+  "instances": {
+    "number_of_instances": 1,
+    "instance_type": "<%= analytics_instance_type %>",
+    "root_device_type": "ebs",
+    "root_device_size": "<%= root_device_size %>"
+  }
+}

--- a/templates/base-secrets.json
+++ b/templates/base-secrets.json
@@ -53,4 +53,11 @@
   "GangliaUrl": "/ganglia",
   "GangliaUser": "opsworks_user - FILL_ME_IN",
   "GangliaPassword": "ganglia_passwork - FILL_ME_IN"
+},
+"elk" : {
+  "_http_auth_comment": "user/pass combo for nginx proxy http auth",
+  "http_auth": {
+    "user": "user - FILL_ME_IN",
+    "pass": "pass - FILL_ME_IN"
+  }
 }

--- a/templates/cluster_config_default.json.erb
+++ b/templates/cluster_config_default.json.erb
@@ -315,6 +315,9 @@
           "root_device_size": "<%= root_device_size %>"
         }
       }
+      <% if include_analytics %>
+        ,<%= ERB.new(analytics_layer_template).result(binding) %>
+      <% end %>
     ],
     "app": {
       "shortname": "matterhorn",


### PR DESCRIPTION
This adds a prompt to the `cluster:new` process that, if "Y", will include the analytics layer configuration in the generated cluster config.