### PR TITLE
hibernate/restore RDS instances during cluster stop/start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Make it easier to add an analytics node via `cluster:new`
 * Allow configtest override for advanced, edge case clusters via `skip_configtest`.
+* RDS hibernation via snapshot + delete & re-creation
 
 ## 1.10.0 - 10/19/2016
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,5 @@ gem 'pry'
 gem 'erubis', '~> 2.7.0'
 gem 'diffy', '~> 3.0.7'
 gem 'simplecov', require: false
+gem 'celluloid'
+gem 'colorize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,13 +13,17 @@ GEM
       jmespath (~> 1.0)
     aws-sdk-resources (2.3.4)
       aws-sdk-core (= 2.3.4)
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     coderay (1.1.0)
+    colorize (0.8.1)
     diff-lcs (1.2.5)
     diffy (3.0.7)
     docile (1.1.5)
     erubis (2.7.0)
+    hitimes (1.2.4)
     i18n (0.7.0)
     jmespath (1.2.4)
       json_pure (>= 1.8.1)
@@ -49,6 +53,8 @@ GEM
     simplecov-html (0.9.0)
     slop (3.6.0)
     thread_safe (0.3.4)
+    timers (4.0.4)
+      hitimes
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
 
@@ -57,7 +63,9 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk (~> 2.3.4)
+  celluloid
   climate_control
+  colorize
   diffy (~> 3.0.7)
   erubis (~> 2.7.0)
   pry
@@ -66,3 +74,6 @@ DEPENDENCIES
   rspec-expectations (~> 3.3.0)
   rspec-mocks (~> 3.3.0)
   simplecov
+
+BUNDLED WITH
+   1.13.1

--- a/README.md
+++ b/README.md
@@ -112,6 +112,19 @@ the parameters and sizes you set in your cluster config. Basic feedback is
 given while the cluster is being created, you can see more information in the
 AWS opsworks console.
 
+At this point your opsworks instances have been initialized but no ec2 instances
+have been created. The RDS instance **has** been created and will be running (and
+incurring AWS costs). If you do not intend to go on to the next step at this time
+you should consider running `./bin/rake rds:hibernate` which will create a 
+snapshot of the db and remove the instance. When you are eventually ready to move
+on to step 6, the `stack:instances:start` command will re-create and restore the
+RDS instance from it's "hibernated" snapshot.
+
+**Note**: running `rds:hibernate` immediately after `admin:cluster:init`
+can sometimes return an error that the RDS instance is in a non-modifiable state.
+This is fine; it's just the instance doing it's usual automated backup when it first 
+comes online. Wait 5-10m or so and try again.
+
 ### Step 6 - Start your ec2 instances
 
 Creating a cluster only instantiates the configuration in OpsWorks. You must
@@ -733,6 +746,21 @@ If you wanted to create a multi-az instance for a non-large cluster, you'd run
 
 and then create your cluster.  This pattern is similar for other RDS-specific
 attributes.
+
+### RDS instance hibernation
+
+Unlike the opsworks ec2 instances, RDS instances cannot be simply turned off/on.
+They either exist and are running, or are deleted. `mh-opsworks` allows for a form
+of RDS "hibernation" that involves taking a final snapshot followed by a deletion
+of the instance. "Restoring" involves recreating the instance from it's final
+snapshot. The naming format of the hibernation snapshot is `[db name]__hibernated__`.
+
+Hibernation of the RDS instance happens automatically during a `stack:instances:stop` 
+operation. Restoration of the RDS instance happens during `stack:instances:start`, with
+the exception of a new, just-initialized cluster, because in that situation the
+RDS instance should already exist.
+
+RDS instances can be manullay hibernated/restored using `rds:hibernate` and `rds:restore`.
 
 ### Potentially problematic aws resource limits
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require './lib/cluster'
+require 'colorize'
 Dir['./lib/tasks/*.rake'].each { |file| load file }
 
 namespace :admin do
@@ -31,8 +32,11 @@ namespace :admin do
           puts %Q|	Instance: #{instance.hostname} => status: #{instance.status}, ec2_instance_id: #{instance.ec2_instance_id}|
         end
       end
+
       puts
       puts %Q|Initializing the cluster does not start instances. To start them, use "./bin/rake stack:instances:start"|
+      puts
+      puts %Q|Initializing the cluster starts your RDS instance! Please run 'rds:hibernate' if you're not starting the cluster right away!|.yellow
     end
 
     desc Cluster::RakeDocs.new('admin:cluster:delete').desc

--- a/lib/cluster/base.rb
+++ b/lib/cluster/base.rb
@@ -2,6 +2,7 @@ module Cluster
   class Base
     require 'uri'
     require 'json'
+    require 'celluloid'
     include ConfigurationHelpers
     include NamingHelpers
     include ClientHelpers

--- a/lib/cluster/instances.rb
+++ b/lib/cluster/instances.rb
@@ -26,7 +26,7 @@ module Cluster
       instances = []
       stack = Cluster::Stack.find_existing
       if stack
-        Cluster::Stack.stop_all
+        Cluster::Stack.stop_all(hibernate_rds=false)
         opsworks_client.describe_instances(stack_id: stack.stack_id).inject([]){ |memo, page| memo + page.instances }.each do |instance|
           opsworks_instance = Cluster::Instance.new(instance.instance_id)
           opsworks_instance.delete

--- a/lib/cluster/naming_helpers.rb
+++ b/lib/cluster/naming_helpers.rb
@@ -21,6 +21,10 @@ module Cluster
         %Q|#{stack_shortname}-database|
       end
 
+      def db_hibernate_snapshot_id
+        %Q|#{rds_name}-hibernated|
+      end
+
       def vpc_name
         %Q|#{stack_shortname}-vpc|
       end

--- a/lib/cluster/waiters.rb
+++ b/lib/cluster/waiters.rb
@@ -3,23 +3,33 @@ module Cluster
     module ClassMethods
 
       def wait_until_rds_instance_available(db_instance_identifier)
-        print "Waiting for RDS instance to be available: "
+        puts "Waiting for RDS instance to be available..."
         rds_client.wait_until(
           :db_instance_available, db_instance_identifier: db_instance_identifier
         ) do |w|
           ::Cluster::Instance.apply_wait_options(w)
         end
-        puts " done!"
+        puts " RDS instance is available!"
+      end
+
+      def wait_for_rds_instance_modification(db_instance_identifier)
+        puts "Waiting for RDS instance modification to complete..."
+        sleep(30)
+        rds_client.wait_until(
+          :db_instance_available, db_instance_identifier: db_instance_identifier
+        ) do |w|
+          ::Cluster::Instance.apply_wait_options(w)
+        end
       end
 
       def wait_until_rds_instance_deleted(db_instance_identifier)
-        print "Waiting for RDS instance to be deleted: "
+        puts "Waiting for RDS instance to be deleted..."
         rds_client.wait_until(
           :db_instance_deleted, db_instance_identifier: db_instance_identifier
         ) do |w|
           ::Cluster::Instance.apply_wait_options(w)
         end
-        puts " done!"
+        puts " RDS instance is deleted!"
       end
 
       def wait_until_deployment_completed(deployment_id)

--- a/lib/tasks/docs/rds:hibernate.txt
+++ b/lib/tasks/docs/rds:hibernate.txt
@@ -1,0 +1,7 @@
+Hibernate the RDS instance
+
+This "hibernates" the RDS instance by saving state to a final snapshot and deletinng the instance.
+
+SEE ALSO:
+
+rds:restore

--- a/lib/tasks/docs/rds:restore.txt
+++ b/lib/tasks/docs/rds:restore.txt
@@ -1,0 +1,7 @@
+Restore the RDS instance
+
+This restores the RDS instance from it's hibernated, snapshot state
+
+SEE ALSO:
+
+rds:hibernate

--- a/lib/tasks/docs/stack:instances:start.txt
+++ b/lib/tasks/docs/stack:instances:start.txt
@@ -12,6 +12,8 @@ Subsequent starts go much faster, maybe 10 to 15 minutes.
 
 Custom tags are created or updated when starting instances via this command.
 
+The cluster's RDS instance is restored from it's "-hibernated" snapshot.
+
 SEE ALSO:
 
 admin:cluster:init, stack:instances:stop

--- a/lib/tasks/docs/stack:instances:stop.txt
+++ b/lib/tasks/docs/stack:instances:stop.txt
@@ -1,7 +1,6 @@
 Stops all instances in the current cluster
 
-This shuts down matterhorn and then stops all instances in the cluster - it's
-useful to idle a cluster when you're not using it.
+This shuts down matterhorn and, stops all instances in the cluster, and hibernates the RDS instance.
 
 SEE ALSO:
 

--- a/lib/tasks/rds.rake
+++ b/lib/tasks/rds.rake
@@ -4,4 +4,14 @@ namespace :rds do
     Cluster::RDS::EventSubscriptionCreator.create
     puts 'Event subscriptions being created.'
   end
+
+  desc Cluster::RakeDocs.new('rds:hibernate').desc
+  task hibernate: ['cluster:configtest', 'cluster:config_sync_check', 'cluster:production_failsafe'] do
+    Cluster::RDS.hibernate
+  end
+
+  desc Cluster::RakeDocs.new('rds:restore').desc
+  task restore: ['cluster:configtest', 'cluster:config_sync_check', 'cluster:production_failsafe'] do
+    Cluster::RDS.restore
+  end
 end


### PR DESCRIPTION
This incorporates a "scripted" hibernate/restore ability for RDS instances. The hibernate operation creates a final snapshot of the instance before deleting it. The restore operation re-creates the rds instance from the final snapshot. 

Some things of note:
* there are some protections to ensure that this can't be run on a "prod" cluster
* i have introduced the use of a ruby gem called 'celluloid' so that the rds operations can be done with some measure of concurrency. By doing this I was able to keep the additional rds operations from significantly impacting the runtime of `stack:instances:stop` and `stack:instances:start`
* the `admin:cluster:init` operation creates/starts the rds instance. if the developer does not subsequently start/stop the cluster, that rds instance will remain running. I added an output message that warns about this and suggests running `rds:hibernate` if the developer doesn't intend to use the cluster immediately.
