### PR TITLE
cluster config `skip_configtest` override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## TO BE RELEASED
 
 * Make it easier to add an analytics node via `cluster:new`
+* Allow configtest override for advanced, edge case clusters via `skip_configtest`.
 
 ## 1.10.0 - 10/19/2016
 

--- a/README.md
+++ b/README.md
@@ -798,6 +798,17 @@ This will tag VPCs, RDS instance, S3 buckets, EC2 instances, and EBS volumes.
 Note that applying tags will update or create new tags, but will not remove existing
 tags.
 
+### Configtest Override
+
+For advanced edge-case use, i.e., *if you really know what you're doing*, you can override
+the automatic cluter config sanity checking by adding the following to your custom
+json block:
+
+    "skip_configtest": true
+    
+This would be useful in a situation where, for example, you wanted to create a stack
+that contained only an **Analytics** node. Without this setting the rake task will fail,
+complaining about a missing Admin layer.
 
 ## TODO
 

--- a/lib/cluster/configuration_helpers.rb
+++ b/lib/cluster/configuration_helpers.rb
@@ -58,6 +58,10 @@ module Cluster
         ['development', 'test'].include?(stack_custom_json[:cluster_env])
       end
 
+      def skip_configtest?
+        stack_custom_json[:skip_configtest]
+      end
+
       def cluster_seed_bucket_name
         stack_custom_json[:cluster_seed_bucket_name]
       end

--- a/lib/tasks/cluster.rake
+++ b/lib/tasks/cluster.rake
@@ -40,7 +40,12 @@ namespace :cluster do
 "
       exit 1
     end
-    config.sane?
+    unless Cluster::Base.skip_configtest?
+      config.sane?
+    else
+      puts "Skipping cluster config sanity check!"
+      true
+    end
   end
 
   desc Cluster::RakeDocs.new('cluster:active').desc


### PR DESCRIPTION
I want to make it possible to create a cluster that contains *only* an analytics node, but the built-in configtest sanity check prevents it. This allows for an override setting.