### PR TITLE
Use RDS db parameter group setting in instance creation and restore

### DIFF
--- a/lib/cluster/config_creator.rb
+++ b/lib/cluster/config_creator.rb
@@ -13,6 +13,7 @@ module Cluster
 
         database_instance_type: 'db.t2.medium',
         database_disk_size: '20',
+        database_param_group: 'dce-oc-mysql-5-6',
         multi_az: false,
 
         admin_instance_type: 't2.medium',
@@ -43,6 +44,7 @@ module Cluster
 
         database_instance_type: 'db.t2.medium',
         database_disk_size: '20',
+        database_param_group: 'dce-oc-mysql-5-6',
         multi_az: false,
 
         admin_instance_type: 'c4.xlarge',
@@ -73,6 +75,7 @@ module Cluster
 
         database_instance_type: 'db.m4.2xlarge',
         database_disk_size: '250',
+        database_param_group: 'dce-oc-mysql-5-6',
         multi_az: true,
 
         admin_instance_type: 'c4.8xlarge',
@@ -100,6 +103,7 @@ module Cluster
 
         database_instance_type: 'db.t2.medium',
         database_disk_size: '20',
+        database_param_group: 'dce-oc-mysql-5-6',
         multi_az: false,
 
         admin_instance_type: 'c4.xlarge',
@@ -127,6 +131,7 @@ module Cluster
 
         database_instance_type: 'db.m4.2xlarge',
         database_disk_size: '250',
+        database_param_group: 'dce-oc-mysql-5-6',
         multi_az: true,
 
         admin_instance_type: 'c4.8xlarge',
@@ -154,6 +159,7 @@ module Cluster
 
         database_instance_type: 'db.t2.medium',
         database_disk_size: '20',
+        database_param_group: 'dce-oc-mysql-5-6',
         multi_az: false,
 
         admin_instance_type: 't2.medium',
@@ -178,6 +184,7 @@ module Cluster
 
         database_instance_type: 'db.t2.large',
         database_disk_size: '50',
+        database_param_group: 'dce-oc-mysql-5-6',
         multi_az: false,
 
         admin_instance_type: 'c4.xlarge',
@@ -202,6 +209,7 @@ module Cluster
 
         database_instance_type: 'db.m4.xlarge',
         database_disk_size: '250',
+        database_param_group: 'dce-oc-mysql-5-6',
         multi_az: true,
 
         admin_instance_type: 'c4.8xlarge',
@@ -229,6 +237,7 @@ module Cluster
 
         database_instance_type: 'db.t2.micro',
         database_disk_size: '20',
+        database_param_group: 'dce-oc-mysql-5-6',
         multi_az: false,
 
         admin_instance_type: 't2.medium',

--- a/templates/cluster_config_ami_builder.json.erb
+++ b/templates/cluster_config_ami_builder.json.erb
@@ -14,6 +14,7 @@
     "db_name": "opencast",
     "db_instance_class": "<%= database_instance_type %>",
     "allocated_storage": "<%= database_disk_size %>",
+    "db_parameter_group_name": "<%= database_param_group %>",
     "master_username": "root",
     "master_user_password": "<%= master_user_password %>",
     "backup_retention_period": 1,

--- a/templates/cluster_config_default.json.erb
+++ b/templates/cluster_config_default.json.erb
@@ -14,6 +14,7 @@
     "db_name": "opencast",
     "db_instance_class": "<%= database_instance_type %>",
     "allocated_storage": "<%= database_disk_size %>",
+    "db_parameter_group_name": "<%= database_param_group %>",
     "master_username": "root",
     "master_user_password": "<%= master_user_password %>",
     "backup_retention_period": 1,

--- a/templates/cluster_config_efs.json.erb
+++ b/templates/cluster_config_efs.json.erb
@@ -14,6 +14,7 @@
     "db_name": "opencast",
     "db_instance_class": "<%= database_instance_type %>",
     "allocated_storage": "<%= database_disk_size %>",
+    "db_parameter_group_name": "<%= database_param_group %>",
     "master_username": "root",
     "master_user_password": "<%= master_user_password %>",
     "backup_retention_period": 1,

--- a/templates/cluster_config_zadara.json.erb
+++ b/templates/cluster_config_zadara.json.erb
@@ -14,6 +14,7 @@
     "db_name": "opencast",
     "db_instance_class": "<%= database_instance_type %>",
     "allocated_storage": "<%= database_disk_size %>",
+    "db_parameter_group_name": "<%= database_param_group %>",
     "master_username": "root",
     "master_user_password": "<%= master_user_password %>",
     "backup_retention_period": 1,


### PR DESCRIPTION
I'm not 100% satisfied with this solution as we should generally avoid putting dce-specific stuff in here, but the alternative seemed bad. Ideally the `admin:cluster:init` task would copy the default mysql 5.6 param group to one named according to the cluster and then modify the necessary settings. The problem is, AWS recommends waiting 5m after a param group is created before using it on a cluster, and I don't want to add 5m to the cluster spin-up process. I may have a better solution (creating the param group in parallel with the vpc infrastructure so it's there and waiting), but want to get a fix in asap.