### PR TITLE
speed up cluster:edit's stack, app & layer updates by exec in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * update rds mysql version
 * Vagrantfile config fix for local-up ssh timeout on Mac OS X (MATT-2293)
 * fix js typo in cluster config templates
+* execute cluster:edit's stack, app & layer updates in parallel
 
 ## 1.12.0 - 01/10/2017
 

--- a/lib/tasks/cluster.rake
+++ b/lib/tasks/cluster.rake
@@ -82,12 +82,17 @@ namespace :cluster do
 
       if ['y','Y'].include?(answer)
         remote_config.sync
-        puts 'updating stack attributes. . .'
-        Cluster::Stack.update
-        puts 'updating app configuration. . .'
-        Cluster::App.update
-        puts 'updating layer configurations. . .'
-        Cluster::Layers.update
+        puts 'updating stack, app & layer attributes. . .'
+        fork do
+          Cluster::Stack.update
+        end
+        fork do
+          Cluster::App.update
+        end
+        fork do
+          Cluster::Layers.update
+        end
+        Process.waitall
       else
         puts "Quitting. Please resolve your config changes and try again."
         exit


### PR DESCRIPTION
I get frustrated with how long the post-config:edit updates take. I looked through the code and didn't see any aspect of them that depended on sequential execution so I parallelized it to make it faster.