### PR TITLE
VPN-only access CloudFormation and Security Group changes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## TO BE RELEASED
 
+## 1.14.0 - 08/16/2017
+
+* Security changes for MATT-2377
+
 ## 1.13.0 - 08/10/2017
 
 * update rds mysql version

--- a/README.zadara.md
+++ b/README.zadara.md
@@ -93,6 +93,8 @@ buckets and add them to the list in the IAM user's inline policy (below).
   proxy.
 * Add the `mh-opsworks-recipes::create-squid-proxy-for-storage-cluster` recipe
   to the layer's `setup` lifecycle. Run it to create the squid3 proxy.
+* Add a rule to the layer's security group (e.g. Utility) that opens port 3128
+  to the IP of your VPSA
 * Create an s3 bucket to hold your snapshots. Default policies and access
   controls should be fine.
 * Create an IAM user with access credentials and a inline policy that looks

--- a/lib/cluster/base.rb
+++ b/lib/cluster/base.rb
@@ -100,6 +100,7 @@ module Cluster
                 "ec2:*",
                 "iam:PassRole",
                 "cloudwatch:*",
+                "logs:*",
                 "elasticloadbalancing:*",
                 "rds:*"
               ],
@@ -125,6 +126,14 @@ module Cluster
                 "Service" => "opsworks.amazonaws.com"
               },
               "Action" => "sts:AssumeRole"
+            },
+            {
+                "Sid": "",
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "vpc-flow-logs.amazonaws.com"
+                },
+                "Action": "sts:AssumeRole"
             }
           ]
         }

--- a/lib/cluster/layer.rb
+++ b/lib/cluster/layer.rb
@@ -49,13 +49,12 @@ module Cluster
 
     def default_security_group_ids
       [
-        security_group_id_for("#{vpc_name}-InstancesAllowedToAccessEFS"),
-        security_group_id_for("AWS-OpsWorks-Custom-Server")
+        security_group_id_for("#{vpc_name}-OpsworksLayerSecurityGroupCommon"),
       ]
     end
 
     def get_security_group_for_public_layer
-      security_group_id_for("#{vpc_name}-DirectAccessToMatterhornDaemon")
+      security_group_id_for( "#{vpc_name}-OpsworksLayerSecurityGroup#{params[:name]}")
     end
 
     def get_security_group_for_private_layer

--- a/lib/cluster/rds.rb
+++ b/lib/cluster/rds.rb
@@ -110,7 +110,7 @@ module Cluster
         db_instance_identifier: rds_name,
         backup_retention_period: rds_config[:backup_retention_period],
         apply_immediately: true,
-        vpc_security_group_ids: [ sg_group_id ]
+        vpc_security_group_ids: sg_group_ids
       })
 
       rds_client.delete_db_snapshot({ db_snapshot_identifier: db_hibernate_snapshot_id })
@@ -147,10 +147,12 @@ module Cluster
       end
     end
 
-    def self.sg_group_id
+    def self.sg_group_ids
       vpc = VPC.find_existing
       sg_finder = SecurityGroupFinder.new(vpc)
-      sg_finder.security_group_id_for('AWS-OpsWorks-Custom-Server')
+      [
+        sg_finder.security_group_id_for('OpsworksLayerSecurityGroupCommon')
+      ]
     end
 
     def self.construct_instance(rds)
@@ -175,7 +177,7 @@ module Cluster
       {
           db_instance_identifier: rds_name,
           db_subnet_group_name: db_subnet_group_name,
-          vpc_security_group_ids: [ sg_group_id ],
+          vpc_security_group_ids: sg_group_ids,
           tags: [{
             key: "opsworks:stack",
             value: stack_config[:name],

--- a/lib/cluster/stack.rb
+++ b/lib/cluster/stack.rb
@@ -204,7 +204,8 @@ module Cluster
         default_instance_profile_arn: instance_profile.arn,
         default_subnet_id: vpc.subnets.first.id,
         default_root_device_type: stack_config.fetch(:default_root_device_type, 'ebs'),
-        default_ssh_key_name: stack_config.fetch(:default_ssh_key_name, '')
+        default_ssh_key_name: stack_config.fetch(:default_ssh_key_name, ''),
+        use_opsworks_security_groups: false
       }
     end
 

--- a/lib/tasks/docs/vpc:create_flowlog.txt
+++ b/lib/tasks/docs/vpc:create_flowlog.txt
@@ -1,0 +1,8 @@
+Create a flowlog for this VPC, useful for debugging VPC and security group issues.
+
+This creates a new cloudwatch log group and a VPC flow log resource.
+For reference see: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html
+
+SEE ALSO:
+
+vpc:delete, vpc:init

--- a/lib/tasks/vpc.rake
+++ b/lib/tasks/vpc.rake
@@ -20,4 +20,13 @@ namespace :vpc do
   task delete: ['cluster:configtest', 'cluster:config_sync_check', 'cluster:production_failsafe'] do
     Cluster::VPC.delete
   end
+
+  desc Cluster::RakeDocs.new('vpc:create_flowlog').desc
+  task create_flowlog: ['cluster:configtest', 'cluster:config_sync_check'] do
+    begin
+      Cluster::VPC.create_flowlog
+    rescue Aws::EC2::Errors::FlowLogAlreadyExists
+      puts "Flow log already exists!"
+    end
+  end
 end

--- a/templates/OpsWorksinVPC.template.erb
+++ b/templates/OpsWorksinVPC.template.erb
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion" : "2010-09-09",
 
-  "Description" : "This template creates a VPC environment for AWS OpsWorks. The stack contains 2 subnets: the first subnet is public and contains a NAT device for internet access from the private subnet. The second subnet is private.",
+  "Description" : "This template creates a VPC environment for AWS OpsWorks. The stack contains 2 subnets: the first subnet is public. The second subnet is private.",
 
   "Parameters" : {
     "CIDRBlock": {
@@ -39,20 +39,6 @@
       "Type": "String",
       "Default": "",
       "ConstraintDescription": "The secondary AZ for future expansion and RDS replication"
-    },
-    "SNSTopicName": {
-      "Description":"The SNS Topic for this stack, used to trigger cloudwatch alarms for NAT instance",
-      "Type": "String",
-      "Default": "",
-      "ConstraintDescription": "this is auto created by mh-opsworks."
-    }
-  },
-
-  "Mappings" : {
-    "AWSNATAMI" : {
-      "us-east-1"      : { "AMI" : "ami-4c9e4b24" },
-      "us-west-1"      : { "AMI" : "ami-2b2b296e" },
-      "us-west-2"      : { "AMI" : "ami-bb69128b" }
     }
   },
 
@@ -131,7 +117,8 @@
       "Properties" : {
         "VpcId" : { "Ref" : "VPC" },
         "Tags" : [
-          { "Key" : "Network", "Value" : "Public" }
+          { "Key" : "Network", "Value" : "Public" },
+          { "Key" : "Name", "Value" : { "Fn::Join" : [ " ", [ { "Ref" : "AWS::StackName" }, "public subnet network acl" ] ] } }
         ]
       }
     },
@@ -222,9 +209,13 @@
     "PrivateRoute" : {
       "Type" : "AWS::EC2::Route",
       "Properties" : {
-        "RouteTableId" : { "Ref" : "PrivateRouteTable" },
+        "RouteTableId" : {
+          "Ref" : "PrivateRouteTable"
+        },
         "DestinationCidrBlock" : "0.0.0.0/0",
-        "InstanceId" : { "Ref" : "NATDevice" }
+        "NatGatewayId" : {
+          "Ref" : "NATGateway"
+        }
       }
     },
 
@@ -273,119 +264,118 @@
       }
     },
 
-    "NATDevice" : {
-      "Type" : "AWS::EC2::Instance",
+    "NATGatewayEIP" : {
+      "Type" : "AWS::EC2::EIP",
       "Properties" : {
-        "InstanceType" : "t2.medium",
-        "SourceDestCheck" : "false",
-        "ImageId" : { "Fn::FindInMap" : [ "AWSNATAMI", { "Ref" : "AWS::Region" }, "AMI" ]},
-        "NetworkInterfaces": [
-          {
-            "AssociatePublicIpAddress": "true",
-            "DeviceIndex": "0",
-            "DeleteOnTermination": "true",
-            "GroupSet": [ { "Ref" : "NATSecurityGroup" } ],
-            "SubnetId" : { "Ref" : "PublicSubnet" }
-          }
-        ],
-        "Tags" : [
-          { "Key" : "Name", "Value" : { "Fn::Join" : [ " ", [ { "Ref" : "AWS::StackName" }, "NAT instance" ] ] } }
-        ]
+        "Domain" : "vpc"
       }
     },
 
-    "NATDeviceAlarmTopic": {
-      "Type": "AWS::SNS::Topic",
-      "Properties": {
-        "TopicName" : { "Ref" : "SNSTopicName"}
+    "NATGateway" : {
+      "Type" : "AWS::EC2::NatGateway",
+      "DependsOn" : "GatewayToInternet",
+      "Properties" : {
+        "AllocationId" : {
+          "Fn::GetAtt" : [
+            "NATGatewayEIP",
+            "AllocationId"
+          ]
+        },
+        "SubnetId" : {
+          "Ref" : "PublicSubnet"
+        }
       }
     },
 
-    "NATDeviceStatusCheckAlarm": {
-      "Type": "AWS::CloudWatch::Alarm",
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions" : [ { "Ref": "NATDeviceAlarmTopic" } ],
-        "AlarmDescription" : { "Fn::Join" : [" ", [ { "Ref": "AWS::StackName" }, " NAT instance status check"  ] ] },
-        "AlarmName" : { "Fn::Join" : ["-", [ { "Ref": "AWS::StackName" }, "NATInstanceStatusCheck"  ] ] },
-        "ComparisonOperator" : "GreaterThanOrEqualToThreshold",
-        "Dimensions" : [
-          {
-            "Name": "InstanceId",
-            "Value": { "Ref": "NATDevice" }
-          }
-        ],
-        "EvaluationPeriods" : 2,
-        "MetricName" : "StatusCheckFailed",
-        "Namespace" : "AWS/EC2",
-        "OKActions" : [ { "Ref": "NATDeviceAlarmTopic" } ],
-        "Period" : 60,
-        "Statistic" : "Maximum",
-        "Threshold" : 1,
-        "Unit" : "Count"
-      }
+    "OpsworksLayerSecurityGroupAnalytics": {
+        "Type": "AWS::EC2::SecurityGroup",
+        "Properties": {
+            "GroupDescription" : "SG for the analytics layer",
+            "VpcId" : { "Ref" : "VPC" },
+            "SecurityGroupIngress" : [
+            ],
+            "SecurityGroupEgress" : [
+            ],
+            "Tags" : [
+              { "Key" : "Name", "Value" : { "Fn::Join" : [ " ", [ { "Ref" : "AWS::StackName" }, "opsworks analytics layer security group" ] ] } }
+            ]
+        }
     },
 
-    "NATSecurityGroup" : {
-      "Type" : "AWS::EC2::SecurityGroup",
-      "Properties" : {
-        "GroupDescription" : "Enable internal access to the NAT device",
-        "VpcId" : { "Ref" : "VPC" },
-        "SecurityGroupIngress" : [
-          { "IpProtocol" : "tcp", "FromPort" : "22",  "ToPort" : "22",  "SourceSecurityGroupId" : { "Ref" : "OpsWorksSecurityGroup" }} ,
-          { "IpProtocol" : "tcp", "FromPort" : "80",  "ToPort" : "80",  "SourceSecurityGroupId" : { "Ref" : "OpsWorksSecurityGroup" }} ,
-          { "IpProtocol" : "tcp", "FromPort" : "443", "ToPort" : "443", "SourceSecurityGroupId" : { "Ref" : "OpsWorksSecurityGroup" } },
-          { "IpProtocol" : "tcp", "FromPort" : "514", "ToPort" : "514", "SourceSecurityGroupId" : { "Ref" : "OpsWorksSecurityGroup" } },
-          { "IpProtocol" : "tcp", "FromPort" : "6514", "ToPort" : "6514", "SourceSecurityGroupId" : { "Ref" : "OpsWorksSecurityGroup" } },
-          { "IpProtocol" : "tcp", "FromPort" : "8081",  "ToPort" : "8081",  "SourceSecurityGroupId" : { "Ref" : "OpsWorksSecurityGroup" }},
-          { "IpProtocol" : "tcp", "FromPort" : "9418",  "ToPort" : "9418",  "SourceSecurityGroupId" : { "Ref" : "OpsWorksSecurityGroup" }},
-          { "IpProtocol" : "tcp", "FromPort" : "11371",  "ToPort" : "11371",  "SourceSecurityGroupId" : { "Ref" : "OpsWorksSecurityGroup" }}
-        ],
-        "SecurityGroupEgress" : [
-          { "IpProtocol" : "tcp", "FromPort" : "22",  "ToPort" : "22",  "CidrIp" : "0.0.0.0/0" } ,
-          { "IpProtocol" : "tcp", "FromPort" : "80",  "ToPort" : "80",  "CidrIp" : "0.0.0.0/0" } ,
-          { "IpProtocol" : "tcp", "FromPort" : "443", "ToPort" : "443", "CidrIp" : "0.0.0.0/0" },
-          { "IpProtocol" : "tcp", "FromPort" : "514", "ToPort" : "514", "CidrIp" : "0.0.0.0/0" },
-          { "IpProtocol" : "tcp", "FromPort" : "6514", "ToPort" : "6514", "CidrIp" : "0.0.0.0/0" },
-          { "IpProtocol" : "tcp", "FromPort" : "8081",  "ToPort" : "8081",  "CidrIp" : "0.0.0.0/0" },
-          { "IpProtocol" : "tcp", "FromPort" : "9418",  "ToPort" : "9418",  "CidrIp" : "0.0.0.0/0" },
-          { "IpProtocol" : "tcp", "FromPort" : "11371",  "ToPort" : "11371",  "CidrIp" : "0.0.0.0/0" }
-        ],
-        "Tags" : [
-          { "Key" : "Name", "Value" : { "Fn::Join" : [ " ", [ { "Ref" : "AWS::StackName" }, "security group" ] ] } }
-        ]
-      }
+    "OpsworksLayerSecurityGroupUtility": {
+        "Type": "AWS::EC2::SecurityGroup",
+        "Properties": {
+            "GroupDescription" : "SG for the utility layer",
+            "VpcId" : { "Ref" : "VPC" },
+            "SecurityGroupIngress" : [
+              { "IpProtocol" : "tcp", "FromPort" : "3128",  "ToPort" : "3128",  "CidrIp" : "10.0.0.0/8" },
+            ],
+            "SecurityGroupEgress" : [
+            ],
+            "Tags" : [
+              { "Key" : "Name", "Value" : { "Fn::Join" : [ " ", [ { "Ref" : "AWS::StackName" }, "opsworks utility layer security group" ] ] } }
+            ]
+        }
     },
 
-    "OpsWorksSecurityGroup" : {
-      "Type" : "AWS::EC2::SecurityGroup",
-      "Properties" : {
-        "GroupDescription" : "Allow the OpsWorks instances to access the NAT device",
-        "VpcId" : { "Ref" : "VPC" },
-        "Tags" : [
-          { "Key" : "Name", "Value" : { "Fn::Join" : [ " ", [ { "Ref" : "AWS::StackName" }, "opsworks nat security group" ] ] } }
-        ]
-      }
+    "OpsworksLayerSecurityGroupAdmin": {
+        "Type": "AWS::EC2::SecurityGroup",
+        "Properties": {
+            "GroupDescription" : "SG for the admin layer",
+            "VpcId" : { "Ref" : "VPC" },
+            "SecurityGroupIngress" : [
+              <% ca_ips.each do |ip| %>
+              { "IpProtocol" : "tcp", "FromPort" : "80",  "ToPort" : "80",  "CidrIp" : "<%= ip %>" },
+              { "IpProtocol" : "tcp", "FromPort" : "443",  "ToPort" : "443",  "CidrIp" : "<%= ip %>" },
+              { "IpProtocol" : "tcp", "FromPort" : "8080",  "ToPort" : "8080",  "CidrIp" : "<%= ip %>" },
+              <% end %>
+            ],
+            "SecurityGroupEgress" : [
+            ],
+            "Tags" : [
+              { "Key" : "Name", "Value" : { "Fn::Join" : [ " ", [ { "Ref" : "AWS::StackName" }, "opsworks admin layer security group" ] ] } }
+            ]
+        }
     },
-    "DirectAccessToMatterhornDaemon" : {
-      "Type" : "AWS::EC2::SecurityGroup",
-      "Properties" : {
-        "GroupDescription" : "Enable direct access to the matterhorn java daemon for matterhorn nodes",
-        "VpcId" : { "Ref" : "VPC" },
-        "SecurityGroupIngress" : [
-          { "IpProtocol" : "tcp", "FromPort" : "8080",  "ToPort" : "8080",  "CidrIp" : "0.0.0.0/0" },
-          { "IpProtocol" : "tcp", "FromPort" : "3128",  "ToPort" : "3128",  "CidrIp" : "10.0.0.0/8" },
-          { "IpProtocol" : "tcp", "FromPort" : "3128",  "ToPort" : "3128",  "CidrIp" : "172.16.0.0/12" },
-          { "IpProtocol" : "tcp", "FromPort" : "3128",  "ToPort" : "3128",  "CidrIp" : "192.168.0.0/16" }
-        ],
-        "SecurityGroupEgress" : [
-          { "IpProtocol" : "tcp", "FromPort" : "8080",  "ToPort" : "8080",  "CidrIp" : "0.0.0.0/0" }
-        ],
-        "Tags" : [
-          { "Key" : "Name", "Value" : { "Fn::Join" : [ " ", [ { "Ref" : "AWS::StackName" }, "matterhorn direct security group" ] ] } }
-        ]
-      }
-    }
+
+    "OpsworksLayerSecurityGroupEngage": {
+        "Type": "AWS::EC2::SecurityGroup",
+        "Properties": {
+            "GroupDescription" : "SG for the engage layer",
+            "VpcId" : { "Ref" : "VPC" },
+            "SecurityGroupIngress" : [
+              { "IpProtocol" : "tcp", "FromPort" : "80",  "ToPort" : "80",  "CidrIp" : "0.0.0.0/0" },
+              { "IpProtocol" : "tcp", "FromPort" : "443",  "ToPort" : "443",  "CidrIp" : "0.0.0.0/0" },
+            ],
+            "SecurityGroupEgress" : [
+            ],
+            "Tags" : [
+              { "Key" : "Name", "Value" : { "Fn::Join" : [ " ", [ { "Ref" : "AWS::StackName" }, "opsworks engage layer security group" ] ] } }
+            ]
+        }
+    },
+
+    "OpsworksLayerSecurityGroupCommon": {
+        "Type": "AWS::EC2::SecurityGroup",
+        "Properties": {
+            "GroupDescription" : "Common SG rules for all layers",
+            "VpcId" : { "Ref" : "VPC" },
+            "SecurityGroupIngress" : [
+              { "IpProtocol" : "tcp", "FromPort" : "0",  "ToPort" : "65535",  "CidrIp" : "10.0.0.0/8" },
+              { "IpProtocol" : "udp", "FromPort" : "0",  "ToPort" : "65535",  "CidrIp" : "10.0.0.0/8" },
+              <% vpn_ips.each_with_index do |ip, index| %>
+              { "IpProtocol" : "tcp", "FromPort" : "0",  "ToPort" : "65535",  "CidrIp" : "<%= ip %>" },
+              { "IpProtocol" : "udp", "FromPort" : "0",  "ToPort" : "65535",  "CidrIp" : "<%= ip %>" },
+              <% end %>
+            ],
+            "SecurityGroupEgress" : [
+            ],
+            "Tags" : [
+              { "Key" : "Name", "Value" : { "Fn::Join" : [ " ", [ { "Ref" : "AWS::StackName" }, "opsworks common layer security group" ] ] } }
+            ]
+        }
+    },
+
   },
 
   "Outputs" : {

--- a/templates/base-secrets.json
+++ b/templates/base-secrets.json
@@ -60,4 +60,12 @@
     "user": "user - FILL_ME_IN",
     "pass": "pass - FILL_ME_IN"
   }
-}
+},
+"_vpn_ips_comment": "list of vpn ips or ranges in cidr block format"
+"vpn_ips": [
+  "cidr FILL_ME_IN", "cidr FILL_ME_IN"
+],
+"_ca_ips_comment": "list of capture agent ips or ranges in cidr block format"
+"ca_ips": [
+  "cidr FILL_ME_IN", "cidr FILL_ME_IN"
+]


### PR DESCRIPTION
Will squash these to a single commit after code review.

These changes do several things related to restricting access control to a set of IPs (VPN and Capture Agents). The CloudFormation template that generates the VPC, NAT and security group resources has been modified quite a bit.

- the NAT instance has been replaced by an instance of AWS NAT Gateway service
- We no longer will use the default opsworks security groups, only our custom ones
- Each layer has it's own security group defined. Each will also use a common security group.
- There is a new rake task for creating a VPC flowlog for debugging

See my comments in the PR diff for a few more details & explanations.