### PR TITLE
moscaler pause/resume tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* new rake tasks for pausing & resuming horizontal scaling: `moscaler:pause` & `moscaler:resume`.
+
 ## 1.14.1 - 08/15/2017
 
 * fix formatting of service role policy doc entry

--- a/README.horizontal-scaling.md
+++ b/README.horizontal-scaling.md
@@ -203,3 +203,12 @@ After updating any of these settings you will need to rerun the recipe, either v
 or `mh-opsworks`:
 
 `./bin/rake stack:commands:execute_recipes_on_layers layers="Ganglia" recipes="mh-opsworks-recipes::install-moscaler"`
+
+### Pausing & Resuming
+
+There are times, partiuclarly during releases when it's necessary that all MH workers be up and online,
+when it's helpful to pause the horizontal scaling. For that there are a pair of rake tasks,
+
+    ./bin/rake moscaler:pause
+    ./bin/rake moscaler:resume
+    

--- a/lib/tasks/docs/moscaler:pause.txt
+++ b/lib/tasks/docs/moscaler:pause.txt
@@ -1,0 +1,8 @@
+Pause the horizontal scaling service.
+
+Removes the cron entries that execute the moscaler horizontal
+scaling service.
+
+SEE ALSO:
+
+moscaler:resume

--- a/lib/tasks/docs/moscaler:resume.txt
+++ b/lib/tasks/docs/moscaler:resume.txt
@@ -1,0 +1,7 @@
+Resume the horizontal scaling service.
+
+Creates the cron entries that execute the horizontal scaling service.
+
+SEE ALSO:
+
+moscaler:pause

--- a/lib/tasks/moscaler.rake
+++ b/lib/tasks/moscaler.rake
@@ -1,0 +1,17 @@
+namespace :moscaler do
+  desc Cluster::RakeDocs.new('moscaler:pause').desc
+  task pause: ['cluster:configtest', 'cluster:config_sync_check'] do
+    Cluster::Deployment.execute_chef_recipes_on_layers(
+        recipes: [ "mh-opsworks-recipes::moscaler-pause" ],
+        layers: ["Ganglia"]
+    )
+  end
+
+  desc Cluster::RakeDocs.new('moscaler:resume').desc
+  task resume: ['cluster:configtest', 'cluster:config_sync_check'] do
+    Cluster::Deployment.execute_chef_recipes_on_layers(
+        recipes: [ "mh-opsworks-recipes::moscaler-resume" ],
+        layers: ["Ganglia"]
+    )
+  end
+end


### PR DESCRIPTION
Two new tasks for pausing/resuming the horizontal scaling. Each executes a corresponding recipe in [mh-opsworks-recipes](harvard-dce/mh-opsworks-recipes).