### PR TITLE
MI-75: Allow use of prepackaged cookbook source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * fail more nicely when VPN/capture agent IPs aren't configured in secrets
 * add NAT Gateway's IP to common security group ingress rules
 * include db parameter group value in rds params
+* `custom_cookbooks_source` can now be s3 (default) or git
 
 ## 1.15.0 - 08/24/2017
 

--- a/README.md
+++ b/README.md
@@ -239,14 +239,45 @@ make your life difficult in a thousand little ways. Don't do it, via
 
 ### Chef
 
-OpsWorks uses [chef](https://chef.io).  You configure the repository that
-contains custom recipes in the stack section of your active
-cluster configuration file.  These options are pretty much passed through to
+OpsWorks uses [chef](https://chef.io).  You configure the source of the custom 
+recipes in the stack section of your active cluster configuration file. 
+These options are pretty much passed through to
 the `opsworks` ruby client. [Details
 here](http://docs.aws.amazon.com/sdkforruby/api/Aws/OpsWorks/Client.html#create_stack-instance_method)
 about what options you can pass through to, say, control security or the
 revision of the custom cookbook that you'd like to use.
 
+There are two options for the custom cookbook source, "s3" (the default) and "git",
+and the choice of which source type to use is presented during the `cluster:new`
+prompt session. The default type of "s3" means your opsworks stack will look for a 
+prepackaged tar.gz archive in the cluster's shared assets bucket. The archive
+must be named named according to the recipe repo tag or branch specified in the
+"revision" setting. The archive is assumed to be the result of running the
+Berkshelf `package` command. [More info here](http://docs.aws.amazon.com/opsworks/latest/userguide/best-practices-packaging-cookbooks-locally.html).
+
+For example the following configuration will look for the cookbook source 
+at "https://s3.amazonaws.com/shared-assets-bucket/mh-opsworks-recipes-develop.tar.gz":
+```
+{
+  "stack": {
+    "chef": {
+      "custom_cookbooks_source": {
+        "type": "s3",
+        "revision": "develop",
+      }
+    }
+  }
+}
+```
+In this case the stack creation code will assemble the s3 archive url based on the 
+revision and the shared assets bucket name. If your configuration includes a custom
+url for the archive that will be used instead.
+
+Using prepackaged archives from s3 allows you to decouple from github and
+[supermarket.chef.io](https://supermarket.chef.io), which could help your
+deployments be more robust because you're eliminating third party dependencies.
+
+A cookbook source type of "git", on the other hand, would look like this:
 
 ```
 {
@@ -263,41 +294,9 @@ revision of the custom cookbook that you'd like to use.
 }
 ```
 
-Rather than use a git repo (which is certainly simple), you can also package
-your recipes into a tarball hosted on s3 - [see the opsworks docs
-here](https://docs.aws.amazon.com/opsworks/latest/userguide/workingcookbook-installingcustom-repo.html).
-
-This allows you to decouple from github and
-[supermarket.chef.io](https://supermarket.chef.io), which could help your
-deployments be more robust because you're eliminating third party dependencies.
-
-If you're using the default
-[mh-opsworks-recipes](https://github.com/harvard-dce/mh-opsworks-recipes), the
-steps are:
-
-* Check out the mh-opsworks-recipes repo.
-* Check out the relevant tag, branch, or commit in the recipe repo.
-* Run `berks package mh-opsworks-recipes-[commit, tag, or branch].tar.gz`.
-* Upload this file to s3, making it public or ensuring your instances have
-  access to it otherwise.
-* Edit your cluster config to look like:
-
-
-```
-{
-  "stack": {
-    "chef": {
-      "custom_cookbooks_source": {
-        "type": "s3",
-        "url": "https://url-to-the-s3-bucket/mh-opsworks-recipes-[commit, tag, or branch].tar.gz",
-      }
-    }
-  }
-}
-```
-
-And then proceed normally - update your chef recipes, deploy, etc. The linked
-archive on s3 will be used for your custom recipes.
+DCE uses a combination of AWS services, including Lambda and CodeBuild, and a Github
+webhook to provide an automated build pipeline for our [mh-opsworks-recipes](https://github.com/harvard-dce/mh-opsworks-recipes) cookbook.
+That project can be found at [harvard-dce/mh-opsworks-builder](https://github.com/harvard-dce/mh-opsworks-builder).
 
 To enable additional debug-level log output from chef, change the `chef_log_level` setting
 in your stack's custom json to "debug".

--- a/lib/cluster/config_creation_session.rb
+++ b/lib/cluster/config_creation_session.rb
@@ -2,7 +2,7 @@ module Cluster
   class ConfigCreationSession
     attr_accessor :variant, :name, :cidr_block_root, :git_url, :git_revision,
       :export_root, :nfs_server_host, :primary_az, :secondary_az, :project_tag,
-      :include_analytics
+      :include_analytics, :cookbook_source_type
 
     def choose_variant
       puts "\nPlease choose the size of the cluster you'd like to deploy.\n\n"
@@ -159,6 +159,16 @@ module Cluster
 
       if include_analytics.downcase == 'y'
         @include_analytics = true
+      end
+    end
+
+    def get_cookbook_source_type
+      print "\nChoose the custom cookbook source [git/S3]: "
+      git_vs_s3 = STDIN.gets.strip.chomp
+      if git_vs_s3.downcase == "git"
+        @cookbook_source_type = "git"
+      else
+        @cookbook_source_type = "s3"
       end
     end
 

--- a/lib/cluster/configuration_helpers.rb
+++ b/lib/cluster/configuration_helpers.rb
@@ -92,6 +92,10 @@ module Cluster
       def stack_custom_tags
         stack_custom_json[:aws_custom_tags] || []
       end
+
+      def get_cookbook_source_s3_url(revision)
+        %Q|https://s3.amazonaws.com/#{shared_asset_bucket_name}/cookbooks/mh-opsworks-recipes-#{revision}.tar.gz|
+      end
     end
 
     def self.included(base)

--- a/lib/tasks/cluster.rake
+++ b/lib/tasks/cluster.rake
@@ -190,6 +190,7 @@ namespace :cluster do
     session.choose_variant
     session.analytics_node
     session.get_cluster_name
+    session.get_cookbook_source_type
     session.get_git_url
     session.get_git_revision
     session.compute_cidr_block_root
@@ -212,7 +213,8 @@ namespace :cluster do
       primary_az: session.primary_az,
       secondary_az: session.secondary_az,
       default_users: JSON.pretty_generate(session.compute_default_users),
-      include_analytics: session.include_analytics
+      include_analytics: session.include_analytics,
+      cookbook_source_type: session.cookbook_source_type
     )
     rc_file = Cluster::RcFileSwitcher.new(config_file: config_file)
     rc_file.write

--- a/spec/lib/cluster/config_creation_session_spec.rb
+++ b/spec/lib/cluster/config_creation_session_spec.rb
@@ -45,6 +45,17 @@ describe Cluster::ConfigCreationSession do
     end
   end
 
+  context '#get_cookbook_source_type' do
+    it 'uses "s3" as default source type' do
+      stub_stacks_with_other_stack_name
+      session = described_class.new
+      allow(STDIN).to receive(:gets).and_return('')
+      session.get_cookbook_source_type
+      expect(session.cookbook_source_type).to eq 's3'
+    end
+
+  end
+
   context '#get_git_url' do
     it 'accepts those beginning with "git@" or "https://"' do
       ['git@github.com:foo', 'https://github'].each do |git_url|

--- a/spec/lib/cluster/config_creator_spec.rb
+++ b/spec/lib/cluster/config_creator_spec.rb
@@ -15,6 +15,7 @@ describe Cluster::ConfigCreator do
     expect(output).to include(config_attributes[:default_users])
     expect(output).to include(config_attributes[:primary_az])
     expect(output).to include(config_attributes[:secondary_az])
+    expect(output).to include(config_attributes[:cookbook_source_type])
   end
 
   it 'has multiple variants' do
@@ -65,6 +66,7 @@ describe Cluster::ConfigCreator do
     default_users = 'afoasdf'
     primary_az = 'us-east-1a'
     secondary_az = 'us-east-1d'
+    cookbook_source_type = 's3'
 
     attributes = {
       name: name,
@@ -75,7 +77,8 @@ describe Cluster::ConfigCreator do
       default_users: default_users,
       primary_az: primary_az,
       secondary_az: secondary_az,
-      include_analytics: true
+      include_analytics: true,
+      cookbook_source_type: cookbook_source_type
     }
   end
 end

--- a/spec/support/cluster_creation_helpers.rb
+++ b/spec/support/cluster_creation_helpers.rb
@@ -8,7 +8,8 @@ module ClusterCreationHelpers
       default_users: '',
       primary_az: 'us-east-1a',
       secondary_az: 'us-east-1d',
-      include_analytics: true
+      include_analytics: true,
+      cookbook_source_type: 's3'
     }
   end
 end

--- a/templates/cluster_config_default.json.erb
+++ b/templates/cluster_config_default.json.erb
@@ -44,8 +44,10 @@
         }<%= base_secrets_content %>
       },
       "custom_cookbooks_source": {
-        "type": "git",
+        "type": "<%= cookbook_source_type %>",
+        <% if cookbook_source_type == "git" %>
         "url": "https://github.com/harvard-dce/mh-opsworks-recipes",
+        <% end %>
         "revision": "develop"
       }
     },

--- a/templates/cluster_config_zadara.json.erb
+++ b/templates/cluster_config_zadara.json.erb
@@ -41,8 +41,10 @@
         }<%= base_secrets_content %>
       },
       "custom_cookbooks_source": {
-        "type": "git",
+        "type": "<%= cookbook_source_type %>",
+        <% if cookbook_source_type == "git" %>
         "url": "https://github.com/harvard-dce/mh-opsworks-recipes",
+        <% end %>
         "revision": "develop"
       }
     },


### PR DESCRIPTION
* adds `cluster:new` prompt for cookbook source type: s3 (default) vs git
* constructs s3 cookbook archive url from shared asset bucket name + revision