### PR TITLE
MI-77: add nat gateway ip to common sg ingress rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * 'activesupport' gem updated to address security vulnerability
 * fail more nicely when VPN/capture agent IPs aren't configured in secrets
+* add NAT Gateway's IP to common security group ingress rules
 
 ## 1.15.0 - 08/24/2017
 

--- a/templates/OpsWorksinVPC.template.erb
+++ b/templates/OpsWorksinVPC.template.erb
@@ -97,6 +97,7 @@
 
     "PublicRoute" : {
       "Type" : "AWS::EC2::Route",
+      "DependsOn": "GatewayToInternet",
       "Properties" : {
         "RouteTableId" : { "Ref" : "PublicRouteTable" },
         "DestinationCidrBlock" : "0.0.0.0/0",
@@ -208,6 +209,7 @@
 
     "PrivateRoute" : {
       "Type" : "AWS::EC2::Route",
+      "DependsOn": "GatewayToInternet",
       "Properties" : {
         "RouteTableId" : {
           "Ref" : "PrivateRouteTable"
@@ -363,6 +365,8 @@
             "SecurityGroupIngress" : [
               { "IpProtocol" : "tcp", "FromPort" : "0",  "ToPort" : "65535",  "CidrIp" : "10.0.0.0/8" },
               { "IpProtocol" : "udp", "FromPort" : "0",  "ToPort" : "65535",  "CidrIp" : "10.0.0.0/8" },
+              { "IpProtocol": "tcp", "FromPort": "0", "ToPort": "65535", "CidrIp" : { "Fn::Join": [ "", [ { "Ref": "NATGatewayEIP" }, "/32" ] ] } },
+              { "IpProtocol": "udp", "FromPort": "0", "ToPort": "65535", "CidrIp" : { "Fn::Join": [ "", [ { "Ref": "NATGatewayEIP" }, "/32" ] ] } },
               <% vpn_ips.each_with_index do |ip, index| %>
               { "IpProtocol" : "tcp", "FromPort" : "0",  "ToPort" : "65535",  "CidrIp" : "<%= ip %>" },
               { "IpProtocol" : "udp", "FromPort" : "0",  "ToPort" : "65535",  "CidrIp" : "<%= ip %>" },


### PR DESCRIPTION
This allows traffic to all nodes from any nodes on the private subnet
for cases where they have to use external dns addresses