### PR TITLE
Add `db_parameter_group_name` to rds cluster config settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * 'activesupport' gem updated to address security vulnerability
 * fail more nicely when VPN/capture agent IPs aren't configured in secrets
 * add NAT Gateway's IP to common security group ingress rules
+* include db parameter group value in rds params
 
 ## 1.15.0 - 08/24/2017
 

--- a/lib/cluster/config_creator.rb
+++ b/lib/cluster/config_creator.rb
@@ -13,6 +13,7 @@ module Cluster
 
         database_instance_type: 'db.t2.medium',
         database_disk_size: '20',
+        database_param_group: 'dce-mh-1x-mysql-5-6',
         multi_az: false,
 
         admin_instance_type: 't2.medium',
@@ -43,6 +44,7 @@ module Cluster
 
         database_instance_type: 'db.t2.medium',
         database_disk_size: '20',
+        database_param_group: 'dce-mh-1x-mysql-5-6',
         multi_az: false,
 
         admin_instance_type: 'c4.xlarge',
@@ -73,6 +75,7 @@ module Cluster
 
         database_instance_type: 'db.m4.2xlarge',
         database_disk_size: '250',
+        database_param_group: 'dce-mh-1x-mysql-5-6',
         multi_az: true,
 
         admin_instance_type: 'c4.8xlarge',
@@ -100,6 +103,7 @@ module Cluster
 
         database_instance_type: 'db.t2.medium',
         database_disk_size: '20',
+        database_param_group: 'dce-mh-1x-mysql-5-6',
         multi_az: false,
 
         admin_instance_type: 'c4.xlarge',
@@ -127,6 +131,7 @@ module Cluster
 
         database_instance_type: 'db.m4.2xlarge',
         database_disk_size: '250',
+        database_param_group: 'dce-mh-1x-mysql-5-6',
         multi_az: true,
 
         admin_instance_type: 'c4.8xlarge',
@@ -154,6 +159,7 @@ module Cluster
 
         database_instance_type: 'db.t2.medium',
         database_disk_size: '20',
+        database_param_group: 'dce-mh-1x-mysql-5-6',
         multi_az: false,
 
         admin_instance_type: 't2.medium',
@@ -178,6 +184,7 @@ module Cluster
 
         database_instance_type: 'db.t2.large',
         database_disk_size: '50',
+        database_param_group: 'dce-mh-1x-mysql-5-6',
         multi_az: false,
 
         admin_instance_type: 'c4.xlarge',
@@ -202,6 +209,7 @@ module Cluster
 
         database_instance_type: 'db.m4.xlarge',
         database_disk_size: '250',
+        database_param_group: 'dce-mh-1x-mysql-5-6',
         multi_az: true,
 
         admin_instance_type: 'c4.8xlarge',
@@ -229,6 +237,7 @@ module Cluster
 
         database_instance_type: 'db.t2.micro',
         database_disk_size: '20',
+        database_param_group: 'dce-mh-1x-mysql-5-6',
         multi_az: false,
 
         admin_instance_type: 't2.medium',

--- a/lib/cluster/rds.rb
+++ b/lib/cluster/rds.rb
@@ -96,7 +96,8 @@ module Cluster
 
       # restore doesn't take these params
       [ :db_name, :preferred_backup_window, :preferred_maintenance_window, :backup_retention_period,
-        :vpc_security_group_ids, :engine_version, :allocated_storage, :master_username, :master_user_password
+        :vpc_security_group_ids, :engine_version, :allocated_storage, :master_username, :master_user_password,
+        :db_parameter_group_name
       ].each do |s|
         parameters.delete(s)
       end
@@ -106,12 +107,18 @@ module Cluster
 
       # restore also doesn't let you set security groups on initial creation, so we have to do that in a follow-up call
       # also, we can now re-enable the backup setting
-      rds_client.modify_db_instance({
-        db_instance_identifier: rds_name,
-        backup_retention_period: rds_config[:backup_retention_period],
-        apply_immediately: true,
-        vpc_security_group_ids: sg_group_ids
-      })
+      modify_params = {
+          db_instance_identifier: rds_name,
+          backup_retention_period: rds_config[:backup_retention_period],
+          vpc_security_group_ids: sg_group_ids,
+          # if unset instance will get the default mysql5.6 param group
+          db_parameter_group_name: rds_config[:db_parameter_group_name]
+      }
+      rds_client.modify_db_instance(modify_params)
+
+      puts "RDS instance restored. Rebooting to apply parameter group and other modifications."
+      rds_client.reboot_db_instance({ db_instance_identifier: rds_name, force_failover: false })
+      wait_until_rds_instance_available(rds_name)
 
       rds_client.delete_db_snapshot({ db_snapshot_identifier: db_hibernate_snapshot_id })
       construct_instance(response.db_instance)

--- a/templates/cluster_config_ami_builder.json.erb
+++ b/templates/cluster_config_ami_builder.json.erb
@@ -14,6 +14,7 @@
     "db_name": "matterhorn",
     "db_instance_class": "<%= database_instance_type %>",
     "allocated_storage": "<%= database_disk_size %>",
+    "db_parameter_group_name": "<%= database_param_group %>",
     "master_username": "root",
     "master_user_password": "<%= master_user_password %>",
     "backup_retention_period": 1,

--- a/templates/cluster_config_default.json.erb
+++ b/templates/cluster_config_default.json.erb
@@ -14,6 +14,7 @@
     "db_name": "matterhorn",
     "db_instance_class": "<%= database_instance_type %>",
     "allocated_storage": "<%= database_disk_size %>",
+    "db_parameter_group_name": "<%= database_param_group %>",
     "master_username": "root",
     "master_user_password": "<%= master_user_password %>",
     "backup_retention_period": 1,

--- a/templates/cluster_config_efs.json.erb
+++ b/templates/cluster_config_efs.json.erb
@@ -14,6 +14,7 @@
     "db_name": "matterhorn",
     "db_instance_class": "<%= database_instance_type %>",
     "allocated_storage": "<%= database_disk_size %>",
+    "db_parameter_group_name": "<%= database_param_group %>",
     "master_username": "root",
     "master_user_password": "<%= master_user_password %>",
     "backup_retention_period": 1,

--- a/templates/cluster_config_zadara.json.erb
+++ b/templates/cluster_config_zadara.json.erb
@@ -14,6 +14,7 @@
     "db_name": "matterhorn",
     "db_instance_class": "<%= database_instance_type %>",
     "allocated_storage": "<%= database_disk_size %>",
+    "db_parameter_group_name": "<%= database_param_group %>",
     "master_username": "root",
     "master_user_password": "<%= master_user_password %>",
     "backup_retention_period": 1,


### PR DESCRIPTION
This is actually a backport of a change in the 5.x branch. We occasionally need the ability to use or test different mysql settings and to do that you have to use a custom db parameter group.