### PR TITLE
MI-100: add vpc filter to security group finder api call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* add vpc filter to security group finder API call because performance
+
 ## 1.17.1 - 06/05/2018
 
 * MI-89: Don't bother specifying ebs optimization in layer settings. Instance types where we'd want

--- a/lib/cluster/security_group_finder.rb
+++ b/lib/cluster/security_group_finder.rb
@@ -7,9 +7,10 @@ module Cluster
     end
 
     def find(name)
-      self.class.ec2_client.describe_security_groups.inject([]){ |memo, page| memo + page.security_groups }.find do |group|
+      vpc_filter = { filters: [{ name: "vpc-id", values: [vpc.vpc_id] }] }
+      self.class.ec2_client.describe_security_groups(vpc_filter).inject([]){ |memo, page| memo + page.security_groups }.find do |group|
         # This is tightly coupled to the implementation in templates/OpsWorksinVPC.template
-        group.group_name.match(/#{name}/) && group.vpc_id == vpc.vpc_id
+        group.group_name.match(/#{name}/)
       end
     end
 


### PR DESCRIPTION
So it doesn't have to fetch the entire list.