### PR TITLE
MI-130: `PermissionsSyncer` correctly updates opsworks user's public key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * MI-125: rename maven cache file
 * MI-127: remove crowdstrike install from runlists
+* MI-130: `PermissionsSyncer` now compares configured user `ssh_key` value with existing and updates if they differ
 
 ## 1.17.2 - 10/25/2018
 

--- a/lib/cluster/permissions_syncer.rb
+++ b/lib/cluster/permissions_syncer.rb
@@ -56,7 +56,7 @@ module Cluster
         if ! user_profile
           create_user_profile(arns_by_username[user_name], ssh_key)
         else
-          if user_profile.ssh_public_key.nil? && (ssh_key != '')
+          if (ssh_key != '') && (user_profile.ssh_public_key != ssh_key)
             update_ssh_key_on_user_profile(user_profile.iam_user_arn, ssh_key)
           end
         end

--- a/lib/cluster/user.rb
+++ b/lib/cluster/user.rb
@@ -17,9 +17,20 @@ module Cluster
         opsworks_permissions: opsworks_permissions,
         stack_id: stack_id
       )
+
+      # checks each opsworks permission entry to see if there is a corresponding iam user entry
+      # if there is not the opsworks permissions are set to read only. the intention is to disable
+      # opsworks access when iam users are removed
       syncer.read_only_privileges_for_unconfigured_users
+
+      # creates a stub iam user (if none exists) for each "users" entry in the cluster config's
       syncer.create_missing_users
+
+      # for each "users" entry in the cluster config, ensures that a user profile exists in the
+      # AWS account's top-level Opsworks User list
       syncer.sync_opsworks_user_profiles
+
+      # updates the opsworks permissions for the stack based on "users" entries in the cluster config
       syncer.set_user_permissions_from_config
     end
   end


### PR DESCRIPTION
Also adding some comments to make sense of user permissions syncer
process