### PR TITLE
MI-144: vpn/ca ips are now in `base-secrets.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * replacing `install-queued-jobs-metric` recipe with expanded `install-opencast-job-metrics`
   Note: a stub of the old recipe remains in the cookbook for backwards compatibility
 * zadara cluster config template was missing chef log level setting
+* MI-144: vpn/ca ips are now in `base-secrets.json` so look for them in the custom json instead of local secrets
 
 ## 1.17.2 - 10/25/2018
 

--- a/lib/cluster/config_checks/secrets_ips.rb
+++ b/lib/cluster/config_checks/secrets_ips.rb
@@ -4,8 +4,11 @@ module Cluster
 
     class VpnCaIpsConfigured < Base
       def self.sane?
-        if stack_secrets.fetch(:vpn_ips, []).empty?
-          raise VpnCaIpsNotConfigured.new('You must set at least the VPN IP ranges in your secrets.json (capture agent IPs are optional).')
+        if stack_custom_json.fetch(:vpn_ips, []).empty?
+          raise VpnCaIpsNotConfigured.new("The VPN IP ranges are missing from your stack's custom_json. These are provided automatically by the `base-secrets.json` for new clusters. For older clusters you can probably get them from your local `secrets.json` file. (Then remove them from `secrets.json`).")
+        end
+        if stack_secrets[:vpn_ips]
+          STDERR.puts "Deprecation notice: VPN and Capture Agent ips are no longer read from `secrets.json` and can be removed.".colorize(:red)
         end
       end
     end

--- a/lib/cluster/vpc.rb
+++ b/lib/cluster/vpc.rb
@@ -143,8 +143,8 @@ module Cluster
     def self.get_cf_template
       erb = Erubis::Eruby.new(File.read('./templates/OpsWorksinVPC.template.erb'))
       attributes = {
-          vpn_ips: stack_secrets[:vpn_ips],
-          ca_ips: stack_secrets[:ca_ips],
+          vpn_ips: stack_custom_json.fetch(:vpn_ips, []),
+          ca_ips: stack_custom_json.fetch(:ca_ips, []),
           ibm_watson_ips: ibm_watson_config.fetch(:ips, []),
           nfs_server_host: storage_config.fetch(:nfs_server_host, nil)
       }


### PR DESCRIPTION
* new cluster creation and configtest now looks for them in the custom json instead of local secrets
* show a deprecation message when values are still in local `secrets.json`