### PR TITLE
MI-150: `cluster:new` now prompts for cookbook revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* MI-150: `cluster:new` asks for cookbook revision, no longer asks for cookbook source type
+
 ## 2.1.0 - 01/15/2019
 
 * MI-144: vpn/ca ips are now in `base-secrets.json` so look for them in the custom json instead of local secrets

--- a/lib/cluster/config_creation_session.rb
+++ b/lib/cluster/config_creation_session.rb
@@ -2,7 +2,7 @@ module Cluster
   class ConfigCreationSession
     attr_accessor :variant, :name, :cidr_block_root, :git_url, :git_revision,
       :export_root, :nfs_server_host, :subnet_azs, :project_tag,
-      :include_analytics, :cookbook_source_type, :include_utility, :sns_email
+      :include_analytics, :cookbook_revision, :include_utility, :sns_email
 
     def choose_variant
       puts "\nPlease choose the size of the cluster you'd like to deploy.\n\n"
@@ -136,7 +136,7 @@ module Cluster
     end
 
     def get_git_revision
-      print "\nThe branch, tag, or revision to deploy [master]: "
+      print "\nThe Opencast branch, tag, or revision to deploy [master]: "
       git_revision = STDIN.gets.strip.chomp
 
       if git_revision.match(/^\s?$/)
@@ -165,13 +165,14 @@ module Cluster
       end
     end
 
-    def get_cookbook_source_type
-      print "\nChoose the custom cookbook source [git/S3]: "
-      git_vs_s3 = STDIN.gets.strip.chomp
-      if git_vs_s3.downcase == "git"
-        @cookbook_source_type = "git"
+    def get_cookbook_revision
+      print "\nEnter the custom Chef cookbook revision, e.g. 'oc-master': "
+      cookbook_revision = STDIN.gets.strip.chomp
+      unless cookbook_revision == ''
+        @cookbook_revision = cookbook_revision
       else
-        @cookbook_source_type = "s3"
+        puts "You must enter a custom cookbook revision or tag"
+        get_cookbook_revision
       end
     end
 

--- a/lib/tasks/cluster.rake
+++ b/lib/tasks/cluster.rake
@@ -197,7 +197,7 @@ namespace :cluster do
 
     session.get_cluster_name
     session.sns_email_subscription
-    session.get_cookbook_source_type
+    session.get_cookbook_revision
     session.get_git_url
     session.get_git_revision
     session.compute_cidr_block_root
@@ -220,7 +220,7 @@ namespace :cluster do
       subnet_azs: session.subnet_azs.join(','),
       default_users: JSON.pretty_generate(session.compute_default_users),
       include_analytics: session.include_analytics,
-      cookbook_source_type: session.cookbook_source_type,
+      cookbook_revision: session.cookbook_revision,
       include_utility: session.include_utility,
       sns_email: session.sns_email
     )

--- a/spec/lib/cluster/config_creation_session_spec.rb
+++ b/spec/lib/cluster/config_creation_session_spec.rb
@@ -56,13 +56,13 @@ describe Cluster::ConfigCreationSession do
     end
   end
 
-  context '#get_cookbook_source_type' do
-    it 'uses "s3" as default source type' do
+  context '#get_cookbook_revision' do
+    it 'sets the cookbook revision' do
       stub_stacks_with_other_stack_name
       session = described_class.new
-      allow(STDIN).to receive(:gets).and_return('')
-      session.get_cookbook_source_type
-      expect(session.cookbook_source_type).to eq 's3'
+      allow(STDIN).to receive(:gets).and_return('foobar')
+      session.get_cookbook_revision
+      expect(session.cookbook_revision).to eq 'foobar'
     end
 
   end

--- a/spec/lib/cluster/config_creator_spec.rb
+++ b/spec/lib/cluster/config_creator_spec.rb
@@ -14,7 +14,7 @@ describe Cluster::ConfigCreator do
     expect(output).to include(variant_attributes[:storage_instance_type])
     expect(output).to include(config_attributes[:default_users])
     expect(output).to include(config_attributes[:subnet_azs])
-    expect(output).to include(config_attributes[:cookbook_source_type])
+    expect(output).to include(config_attributes[:cookbook_revision])
   end
 
   it 'has multiple variants' do
@@ -64,7 +64,7 @@ describe Cluster::ConfigCreator do
     app_git_revision = 'unique_revision'
     default_users = 'afoasdf'
     subnet_azs = 'us-east-1a,us-east-1d'
-    cookbook_source_type = 's3'
+    cookbook_revision = 'oc-master'
 
     attributes = {
       name: name,
@@ -75,7 +75,7 @@ describe Cluster::ConfigCreator do
       default_users: default_users,
       subnet_azs: subnet_azs,
       include_analytics: true,
-      cookbook_source_type: cookbook_source_type,
+      cookbook_revision: cookbook_revision,
       include_utility: true,
       base_public_ami_id: "ami-12345",
       base_private_ami_id: "ami-09876"

--- a/spec/support/cluster_creation_helpers.rb
+++ b/spec/support/cluster_creation_helpers.rb
@@ -8,7 +8,7 @@ module ClusterCreationHelpers
       default_users: '',
       subnet_azs: ['us-east-1a','us-east-1d','us-east-1f','us-east-1b'],
       include_analytics: true,
-      cookbook_source_type: 's3',
+      cookbook_revision: 'oc-master',
       include_utility: true,
       base_public_ami_id: "ami-12345",
       base_private_ami_id: "ami-09876",

--- a/templates/cluster_config_ami_builder.json.erb
+++ b/templates/cluster_config_ami_builder.json.erb
@@ -31,11 +31,9 @@
         }<%= base_secrets_content %>
       },
       "custom_cookbooks_source": {
-        "type": "<%= cookbook_source_type %>",
-        <% if cookbook_source_type == "git" %>
-        "url": "https://github.com/harvard-dce/mh-opsworks-recipes",
-        <% end %>
-        "revision": "oc-opsworks-5.x-recipes"
+        "_comment": "Change 'type' to 'git' and add 'url': 'https://github.com/harvard-dce/mh-opsworks-recipes' to fetch from github vs s3 prepackaged",
+        "type": "s3",
+        "revision": "<%= cookbook_revision %>"
       }
     },
     "layers": [

--- a/templates/cluster_config_default.json.erb
+++ b/templates/cluster_config_default.json.erb
@@ -45,11 +45,9 @@
         }<%= base_secrets_content %>
       },
       "custom_cookbooks_source": {
-        "type": "<%= cookbook_source_type %>",
-        <% if cookbook_source_type == "git" %>
-        "url": "https://github.com/harvard-dce/mh-opsworks-recipes",
-        <% end %>
-        "revision": "oc-opsworks-5.x-recipes"
+        "_comment": "Change 'type' to 'git' and add 'url': 'https://github.com/harvard-dce/mh-opsworks-recipes' to fetch from github vs s3 prepackaged",
+        "type": "s3",
+        "revision": "<%= cookbook_revision %>"
       }
     },
     "layers": [

--- a/templates/cluster_config_zadara.json.erb
+++ b/templates/cluster_config_zadara.json.erb
@@ -45,11 +45,9 @@
         }<%= base_secrets_content %>
       },
       "custom_cookbooks_source": {
-        "type": "<%= cookbook_source_type %>",
-        <% if cookbook_source_type == "git" %>
-        "url": "https://github.com/harvard-dce/mh-opsworks-recipes",
-        <% end %>
-        "revision": "oc-opsworks-5.x-recipes"
+        "_comment": "Change 'type' to 'git' and add 'url': 'https://github.com/harvard-dce/mh-opsworks-recipes' to fetch from github vs s3 prepackaged",
+        "type": "s3",
+        "revision": "<%= cookbook_revision %>"
       }
     },
     "layers": [


### PR DESCRIPTION
... and no longer prompts for cookbook source type.

I left out the use of a default revision because there's no sensible place to
keep it that isn't hardcoded or awkward.