### PR TITLE
Add tasks for hibernate/restore zadara via the management api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## TO BE RELEASED
 
 * MI-150: `cluster:new` asks for cookbook revision, no longer asks for cookbook source type
+* MI-149: adding tasks to hibernate/restore the dev zadara vpsa
 
 ## 2.1.0 - 01/15/2019
 

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -61,6 +61,7 @@ require './lib/cluster/config_checks/json_format'
 require './lib/cluster/config_checks/bucket_configs'
 require './lib/cluster/config_checks/real_users'
 require './lib/cluster/config_checks/secrets_ips'
+require './lib/cluster/zadara'
 
 module Cluster
   class JSONFormatError < StandardError; end

--- a/lib/cluster/base.rb
+++ b/lib/cluster/base.rb
@@ -3,6 +3,7 @@ module Cluster
     require 'uri'
     require 'json'
     require 'concurrent-ruby'
+    require 'net/http'
     include ConfigurationHelpers
     include NamingHelpers
     include ClientHelpers
@@ -33,6 +34,11 @@ module Cluster
 
     def self.external_storage?
       storage_config[:type] == 'external'
+    end
+
+    def self.show_zadara_tasks?
+      stack_name = config.parsed[:stack][:name]
+      external_storage? && ! stack_name.match(/prod|prd/i)
     end
 
     def self.instance_profile_policy_document

--- a/lib/cluster/configuration_helpers.rb
+++ b/lib/cluster/configuration_helpers.rb
@@ -95,6 +95,10 @@ module Cluster
         stack_custom_json.fetch(:storage, {})
       end
 
+      def zadara_api_config
+        stack_custom_json.fetch(:zadara_manage_api, {})
+      end
+
       def cluster_config_bucket_name
         stack_secrets[:cluster_config_bucket_name] ||
           config.parsed_secrets[:stack].fetch(:secrets, {})[:cluster_config_bucket_name]

--- a/lib/cluster/zadara.rb
+++ b/lib/cluster/zadara.rb
@@ -1,0 +1,81 @@
+module Cluster
+  class Zadara < Base
+
+    def self.all
+      resp_data = JSON.parse(api_request("GET", "vpsas.json").body)
+      resp_data["data"]
+    end
+
+    def self.find_vpsa
+      all.find do |vpsa|
+        vpsa["ip_address"] == storage_config[:nfs_server_host]
+      end
+    end
+
+    def self.hibernate
+      vpsa = find_vpsa
+      unless vpsa["name"].downcase.match("dev")
+        raise VpsaNotHibernatable.new(
+            "Refusing to hibernate vpsa '#{vpsa["name"]}': Not a 'dev' vpsa!")
+      end
+      unless vpsa["status"] == "created"
+        raise VpsaStatusError.new("VPSA is not online")
+      end
+      resp = api_request("POST", "vpsas/#{vpsa["id"]}/hibernate.json")
+      if resp.code != "201"
+        raise HttpError.new(resp.code, resp.message)
+      end
+      puts "Success. VPSA '#{vpsa["name"]}' is now hibernating."
+    end
+
+    def self.restore
+      vpsa = find_vpsa
+      unless vpsa["name"].downcase.match("dev")
+        raise VpsaNotHibernatable.new(
+            "Refusing to restore vpsa '#{vpsa["name"]}': Not a 'dev' vpsa!")
+      end
+      unless vpsa["status"] == "hibernated"
+        raise VpsaStatusError.new("VPSA is already online")
+      end
+      resp = api_request("POST", "vpsas/#{vpsa["id"]}/restore.json")
+      if resp.code != "201"
+        raise HttpError.new(resp.code, resp.message)
+      end
+      puts "Success. VPSA '#{vpsa["name"]}' is now being restored."
+    end
+
+    private
+
+    def self.api_request(method, path)
+      uri = URI.join(zadara_api_config[:api_endpoint], path)
+      api_token = zadara_api_config[:api_token]
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+
+      req = method.upcase == "POST" ?
+        Net::HTTP::Post.new(uri) :
+        Net::HTTP::Get.new(uri)
+
+      req.add_field("Content-Type", "application/json")
+      req.add_field("X-Token", api_token)
+
+      http.request(req)
+    end
+  end
+
+  class HttpError < StandardError
+    attr_reader :code, :message
+
+    def initialize( code, message )
+      @code, @message = code, message
+    end
+
+    def to_s
+      "HTTP request failed (NOK) => #{@code} #{@message}"
+    end
+  end
+
+  class VpsaNotHibernatable < StandardError; end
+  class VpsaStatusError < StandardError; end
+end

--- a/lib/tasks/docs/zadara:hibernate.txt
+++ b/lib/tasks/docs/zadara:hibernate.txt
@@ -1,0 +1,5 @@
+Hibernate the Zadara VPSA attached to this cluster
+
+SEE ALSO:
+
+zadara:restore, zadara:status

--- a/lib/tasks/docs/zadara:restore.txt
+++ b/lib/tasks/docs/zadara:restore.txt
@@ -1,0 +1,5 @@
+Restore the Zadara VPSA attached to this cluster
+
+SEE ALSO:
+
+zadara:hibernate, zadara:status

--- a/lib/tasks/docs/zadara:status.txt
+++ b/lib/tasks/docs/zadara:status.txt
@@ -1,0 +1,5 @@
+Show the status of the Zadara VPSA attached to this cluster
+
+SEE ALSO:
+
+zadara:hibernate, zadara:restore

--- a/lib/tasks/zadara.rake
+++ b/lib/tasks/zadara.rake
@@ -1,0 +1,22 @@
+
+if Cluster::Base.show_zadara_tasks?
+  namespace :zadara do
+    desc Cluster::RakeDocs.new('zadara:status').desc
+    task status: ['cluster:configtest', 'cluster:config_sync_check'] do
+      vpsa = Cluster::Zadara.find_vpsa
+      if vpsa
+        puts "VPSA '#{vpsa["name"]}' status is '#{vpsa["status"]}'"
+      end
+    end
+
+    desc Cluster::RakeDocs.new('zadara:hibernate').desc
+    task hibernate: ['cluster:configtest', 'cluster:config_sync_check', 'cluster:production_failsafe'] do
+      Cluster::Zadara.hibernate
+    end
+
+    desc Cluster::RakeDocs.new('zadara:restore').desc
+    task restore: ['cluster:configtest', 'cluster:config_sync_check', 'cluster:production_failsafe'] do
+      Cluster::Zadara.restore
+    end
+  end
+end


### PR DESCRIPTION
Now that staging (and optionally other dev clusters) are backed by external zadara storage we need a way for devs to easily hibernate and restore the vpsa.

### new tasks
* zadara:hibernate
* zadara:restore
* zadara:status

### to protect against some kind of accidental hiberation of non-dev vpsas
* these tasks are only available to rake if the following conditions are met:
  * the cluster is configured with "external" storage
  * the opsworks stack name does not match `/(prod|prd)/i`
* the hibernate/restore tasks will raise an exception if the vpsa's name does not include the string "dev"

### zadara provisioning api
* The new tasks work by interacting with Zadara's provisioning api, documented at http://provisioning-portal-api.zadarastorage.com
* api auth makes use of a token value that is now included in the `base-secrets.json` file of the **test** aws account's cluster config bucket