### PR TITLE
MI-158: restore/hibernate vpsa during `stack:instances:start|stop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* MI-158: hibernate/restore vpsa during `stack:intances:start|stop`
+
 ## 2.2.0 - 02/13/2019
 
 * MI-150: `cluster:new` asks for cookbook revision, no longer asks for cookbook source type

--- a/lib/cluster/zadara.rb
+++ b/lib/cluster/zadara.rb
@@ -44,6 +44,26 @@ module Cluster
       puts "Success. VPSA '#{vpsa["name"]}' is now being restored."
     end
 
+    def self.prompt_to(action)
+      vpsa = Cluster::Zadara.find_vpsa
+      if vpsa
+        puts "VPSA '#{vpsa["name"]}' status is '#{vpsa["status"]}'"
+        print "\n#{action} the VPSA? [Y/n]: "
+        do_action = STDIN.gets.strip.chomp
+        do_action.downcase != 'n'
+      end
+    end
+
+    def self.is_online?
+      vpsa = Cluster::Zadara.find_vpsa
+      vpsa["status"] == "created"
+    end
+
+    def self.is_hibernated?
+      vpsa = Cluster::Zadara.find_vpsa
+      vpsa["status"] == "hibernated"
+    end
+
     private
 
     def self.api_request(method, path)


### PR DESCRIPTION
When you run `stack:instances:start` or `stack:instances:stop` **and** the cluster uses external zadara storage, prompt the user to hibernate/restore the vpsa (default Y).