### PR TITLE
MI-185: add rds cluster's readonly endpoint to deploy config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* MI-185: add readonly rds cluster endpoint to deploy config
+
 ## 2.5.0 - 01/13/2020
 
 * OPC-357 HLS CORS requires extra headers

--- a/lib/cluster/stack.rb
+++ b/lib/cluster/stack.rb
@@ -254,7 +254,8 @@ module Cluster
         custom_json[:deploy] = {
             app_config[:shortname].to_sym => {
                 :database => {
-                    :host => rds_cluster.endpoint
+                    :host => rds_cluster.endpoint,
+                    :readonly_op_host => rds_cluster.reader_endpoint
                 }
             }
         }


### PR DESCRIPTION
This adds an additional readonly endpoint value to the deploy config
(which ends up in the stack's custom json and is accessible to recipes)

This change corresponds to an update to the write-root-my-dot-conf
recipe which configures the mysqldump operation to use this readonly
endpoint