### PR TITLE
MI-186: aurora version upgrade prep

### DIFF
--- a/lib/cluster/configuration_helpers.rb
+++ b/lib/cluster/configuration_helpers.rb
@@ -52,7 +52,8 @@ module Cluster
       end
 
       def rds_supports_performance_insights?
-        !!(rds_config[:db_instance_class] =~ /db\.r(\d)/)
+        # it's only the t2/t3 class options that don't support this now
+        !(rds_config[:db_instance_class] =~ /db\.t(\d)/)
       end
 
       def deployment_config

--- a/lib/tasks/rds.rake
+++ b/lib/tasks/rds.rake
@@ -11,7 +11,8 @@ namespace :rds do
 
   desc Cluster::RakeDocs.new('rds:update').desc
   task update: ['cluster:configtest', 'cluster:config_sync_check', 'cluster:production_failsafe'] do
-    Cluster::RDS.update
+    update_now = ENV.fetch('update_now', 'false').strip.downcase == 'true'
+    Cluster::RDS.update(update_now)
   end
 
   desc Cluster::RakeDocs.new('rds:stop').desc

--- a/templates/RDSCluster.template.yml
+++ b/templates/RDSCluster.template.yml
@@ -62,6 +62,11 @@ Resources:
       Family: 'aurora5.6'
       Parameters:
         lower_case_table_names: "1"
+        # this just omits some unnecessary data from the replication messages
+        aurora_enable_repl_bin_log_filtering: "1"
+        # this turns on a "zero-downtime reboot" feature
+        # see https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Replication.html#AuroraMySQL.Replication.Availability
+        aurora_enable_zdr: "1"
 
 
   DBParameterGroup:
@@ -77,6 +82,8 @@ Resources:
 
   DBCluster:
     Type: 'AWS::RDS::DBCluster'
+    # This attribute indicates what to do with the resource when the Cfn stack is deleted
+    # default for rds clusters is "Snapshot" but that would interfere with our automated processes
     DeletionPolicy: Delete
     Properties:
       DBClusterIdentifier: !Ref DBClusterIdentifier
@@ -84,6 +91,7 @@ Resources:
       BackupRetentionPeriod: !Ref BackupRetentionPeriod
       DBClusterParameterGroupName: !Ref DBClusterParameterGroup
       DBSubnetGroupName: !Ref DBSubnetGroup
+      DeletionProtection: true
       Engine: "aurora"
       EngineMode: provisioned
       MasterUsername: !Ref DBMasterUser
@@ -91,18 +99,23 @@ Resources:
       DatabaseName: !Ref DBName
       PreferredBackupWindow: !Ref PreferredBackupWindow
       PreferredMaintenanceWindow: !Ref PreferredMaintenanceWindow
+      # these settings only indicate which log types (if/when enabled)
+      # we'd like to have go to cloudwatch logs
       EnableCloudwatchLogsExports:
+          # these are always turned on
         - "error"
+          # these are turned off; turn on only for debugging/diagnosing
         - "general"
+          # these are turned on via the paramter group above
         - "slowquery"
       VpcSecurityGroupIds:
       - {'Fn::ImportValue': !Sub '${ParentVpcStack}-common-sg-id'}
 
   DBInstance1:
     Type: 'AWS::RDS::DBInstance'
+    # See note on the cluster resource
     DeletionPolicy: Delete
     Properties:
-      AllowMajorVersionUpgrade: false
       AutoMinorVersionUpgrade: false
       CopyTagsToSnapshot: true
       Engine: "aurora"
@@ -116,9 +129,10 @@ Resources:
 
   DBInstance2:
     Type: 'AWS::RDS::DBInstance'
+    # See note on the cluster resource
+    DeletionPolicy: Delete
     Condition: CreateReplica
     Properties:
-      AllowMajorVersionUpgrade: false
       AutoMinorVersionUpgrade: false
       CopyTagsToSnapshot: true
       Engine: "aurora"
@@ -131,6 +145,11 @@ Resources:
       MonitoringRoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/rds-monitoring-role"
 
   DBClusterEventSubscription:
+    # this adds rds events to our general feed so we can subscribe
+    # to various things and take actions. For instance, in our dev account
+    # there is a lambda function that watches for cases where an
+    # rds cluster was started because it was hibernated for longer than
+    # the 7 day max set by AWS, and then turns them off again
     Type: 'AWS::RDS::EventSubscription'
     Properties:
       EventCategories:


### PR DESCRIPTION
This change doesn't actually "do" the upgrade; I'm only making a few changes here in preparation for the upgrade. Here's what it's actually doing:

* Enabling a couple of aurora features at the cluster level. One is just a little network efficiency thing. The other turns on a feature that helps clients maintain connections during reboots. I'm not sure we'd ever need it since we'd likely top opencast during reboots, but you never know. Spontaneous reboots do occasionally happen.
* Turning on DeletionProtection at the cluster level. This is something that should have been turned on all along. It just protects against accidental deletion (that's all! no big deal!) of the cluster/instances.
* Changed the `rds:update` task so that by default it now generates a cloudformation change set
  that must be manually approved & executed.
  `rds:update update_now=true` can be used for non-interactive updates
* added a bunch of comments to the template to help my future sanity

It should be pretty simple to test the update changeset bit by checking out this branch and doing `./bin/rake rds:update`. You can then go into the cloudformation web console and find the stack for your cluster, `my-cluster-rds` for example. Switch to the Change sets tab and confirm the change set is there. You can just delete it at that point.