### PR TITLE
OPC-528 update tagging to match huit schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ opencast cluster.
 ## Requirements
 
 * Ruby 2
+* Git
 * Appropriately configured aws rights linked to an access key
 * A POSIX operating system
 
@@ -728,9 +729,7 @@ other) UIs.
 
 ### Custom Tags
 
-When you create a new cluster you are prompted to input a value for the
-`Project` tag, the default value is `MH`. You can also do `rake cluster:edit`
-to add or change tags in the custom json section.
+You can run `rake cluster:edit` to add or change tags in the custom json section.
 
 ```
 {
@@ -755,14 +754,10 @@ to add or change tags in the custom json section.
 
 Tags are applied to VPCs, RDS instance, and S3 buckets, when you do `rake
 admin:cluster:init` (when these resources are created). EC2 instances and EBS
-volumes have tags applied every time you do `rake stack:instances:start`. Note
-that if you start the instance for the first time from the AWS Opsworks
-console, the instance will not be tagged.
+volumes have tags applied when the Opsworks stack is first brought up as the
+instances and volumes don't actually exist prior to that. 
 
-Tags can also be applied to the cluster via command `rake admin:cluster:tag`.
-This will tag VPCs, RDS instance, S3 buckets, EC2 instances, and EBS volumes.
-Note that applying tags will update or create new tags, but will not remove existing
-tags.
+For bulk management of tags or re-tagging please use the AWS [Tag Editor](https://console.aws.amazon.com/resource-groups/tag-editor/find-resources) console.
 
 ### Configtest Override
 

--- a/Rakefile
+++ b/Rakefile
@@ -48,7 +48,7 @@ namespace :admin do
       puts
       puts %Q|Initializing the cluster does not start instances. To start them, use "./bin/rake stack:instances:start"|
       puts
-      puts %Q|Initializing the cluster starts your RDS cluster! Please run 'rds:cluster' if you're not starting the opsworks cluster right away!|.yellow
+      puts %Q|Initializing the cluster starts your RDS cluster! Please run 'rds:stop' if you're not starting the opsworks cluster right away!|.yellow
     end
 
     desc Cluster::RakeDocs.new('admin:cluster:delete').desc
@@ -111,22 +111,6 @@ namespace :admin do
 
       puts 'deleting configuration files'
       Cluster::RemoteConfig.new.delete
-    end
-
-    desc Cluster::RakeDocs.new('admin:cluster:tag').desc
-    task tag: ['cluster:configtest', 'cluster:config_sync_check'] do
-      puts 'tagging instances and volumes'
-      Cluster::Instances.create_custom_tags
-
-      puts 'tagging vpc'
-      Cluster::VPC.create_custom_tags
-
-      puts 'tagging rds instance'
-      Cluster::RDS.create_custom_tags
-
-      puts 'tagging s3 buckets'
-      Cluster::S3Bucket.create_custom_tags(Cluster::Base.distribution_bucket_name)
-      Cluster::S3Bucket.create_custom_tags(Cluster::Base.s3_file_archive_bucket_name)
     end
 
     desc Cluster::RakeDocs.new('admin:cluster:subscribe').desc

--- a/lib/cluster/config_creation_session.rb
+++ b/lib/cluster/config_creation_session.rb
@@ -1,7 +1,7 @@
 module Cluster
   class ConfigCreationSession
     attr_accessor :variant, :name, :cidr_block_root, :git_url, :git_revision,
-      :export_root, :nfs_server_host, :subnet_azs, :project_tag,
+      :export_root, :nfs_server_host, :subnet_azs,
       :include_analytics, :cookbook_revision, :include_utility, :sns_email
 
     def choose_variant
@@ -20,15 +20,6 @@ module Cluster
       return choose_variant unless keys.include?(variant_choice)
 
       @variant = variant_choice
-    end
-
-    def get_project_tag
-      print "\nWhat value for Project Tag? [MH]: "
-      project_tag = STDIN.gets.strip.chomp
-
-      # the default is set in the template mainly because, in tests, this isn't
-      # run and project_tag doesnt' get a default value
-      @project_tag = project_tag
     end
 
     def zadara_variant?

--- a/lib/cluster/config_creator.rb
+++ b/lib/cluster/config_creator.rb
@@ -164,7 +164,6 @@ module Cluster
       base_secrets = %Q|, #{get_base_secrets_content}|
 
       all_attributes = attributes.merge(variant_attributes).
-        merge(project_tag).
         merge(base_secrets_content: base_secrets).
         merge(database_user_info).
         merge(s3_distribution_bucket_name_from(attributes[:name])).
@@ -203,17 +202,6 @@ module Cluster
     def utility_layer_content
       {
         utility_layer_template: File.read('templates/utility_layer.json.erb')
-      }
-    end
-
-    def project_tag
-      if attributes[:project_tag].nil? || attributes[:project_tag].empty?
-        tag = "MH"
-      else
-        tag = attributes[:project_tag]
-      end
-      {
-        project_tag: tag
       }
     end
 

--- a/lib/cluster/instances.rb
+++ b/lib/cluster/instances.rb
@@ -89,22 +89,5 @@ module Cluster
         end
       end
     end
-
-    def self.create_custom_tags
-      if stack_custom_tags.empty?
-        return
-      end
-
-      resource_ids = Stack.find_volume_ids
-      find_existing.each do |instance|
-        resource_ids.push(instance.ec2_instance_id)
-      end
-
-      ec2_client.create_tags({
-          dry_run: false,
-          resources: resource_ids,
-          tags: stack_custom_tags
-      })
-    end
   end
 end

--- a/lib/cluster/rds.rb
+++ b/lib/cluster/rds.rb
@@ -118,17 +118,6 @@ module Cluster
       Aws::RDS::DBInstance.new(rds.db_instance_identifier, client: rds_client)
     end
 
-    def self.create_custom_tags
-      if stack_custom_tags.empty?
-        return
-      end
-
-      rds_client.add_tags_to_resource({
-        resource_name: rds_db_cluster_arn,
-        tags: stack_custom_tags
-      })
-    end
-
     def self.get_parameters
       base_parameters = rds_config
       parameters = [

--- a/lib/cluster/s3_bucket.rb
+++ b/lib/cluster/s3_bucket.rb
@@ -50,18 +50,5 @@ module Cluster
     def self.construct_bucket(name)
       Aws::S3::Bucket.new(name, client: s3_client)
     end
-
-    def self.create_custom_tags(name)
-      if stack_custom_tags.empty?
-        return
-      end
-
-      s3_client.put_bucket_tagging({
-        bucket: "#{name}",
-        tagging: {tag_set: stack_custom_tags},
-        use_accelerate_endpoint: false
-      })
-
-    end
   end
 end

--- a/lib/cluster/vpc.rb
+++ b/lib/cluster/vpc.rb
@@ -280,17 +280,5 @@ module Cluster
         name_tag.value
       end
     end
-
-    def self.create_custom_tags
-      if stack_custom_tags.empty?
-        return
-      end
-
-      vpc = find_existing
-      vpc.create_tags({
-          dry_run: false,
-          tags: stack_custom_tags
-      })
-    end
   end
 end

--- a/lib/tasks/cluster.rake
+++ b/lib/tasks/cluster.rake
@@ -182,7 +182,6 @@ namespace :cluster do
   task :new do
     session = Cluster::ConfigCreationSession.new
     session.local_vs_opsworks
-    session.get_project_tag
     session.choose_variant
 
     if ! session.ami_builder?
@@ -211,7 +210,6 @@ namespace :cluster do
     config_file = Cluster::RemoteConfig.create(
       name: session.name,
       variant: session.variant,
-      project_tag: session.project_tag,
       cidr_block_root: session.cidr_block_root,
       app_git_url: session.git_url,
       app_git_revision: session.git_revision,

--- a/lib/tasks/docs/admin:cluster:tag.txt
+++ b/lib/tasks/docs/admin:cluster:tag.txt
@@ -1,6 +1,0 @@
-Tags resources in cluster with custom tags
-
-Resources include instances, their volumes, rds instances, s3 buckets,
-and vpcs.
-
-Custom tags are defined in the custom_json in the cluster config.

--- a/lib/tasks/stack.rake
+++ b/lib/tasks/stack.rake
@@ -159,7 +159,6 @@ namespace :stack do
       end
 
       Cluster::Stack.start_all(num_workers)
-      Cluster::Instances.create_custom_tags
     end
   end
 

--- a/templates/base-secrets.json
+++ b/templates/base-secrets.json
@@ -75,4 +75,8 @@
   "id": "vpc-1234567890xx",
   "name": "some-other-vpc"
 }
+],
+"aws_custom_tags": [
+  {"key":  "project", "value":  "foo"},
+  {"key":  "department", "value":  "bar"}
 ]

--- a/templates/cluster_config_default.json.erb
+++ b/templates/cluster_config_default.json.erb
@@ -22,10 +22,6 @@
         "opsworks": {
           "chef_log_level": "info"
         },
-        "aws_custom_tags": [
-            {"key": "OU", "value": "DE"},
-            {"key": "Project", "value": "<%= project_tag %>"}
-        ],
         "opencast_repo_root": "/opt/opencast",
         "opencast_log_directory": "/opt/opencast/log",
         "local_workspace_root": "/var/opencast-workspace",

--- a/templates/cluster_config_zadara.json.erb
+++ b/templates/cluster_config_zadara.json.erb
@@ -22,10 +22,6 @@
         "opsworks": {
           "chef_log_level": "info"
         },
-        "aws_custom_tags": [
-            { "key": "OU", "value": "DE" },
-            { "key": "Project", "value": "<%= project_tag %>" }
-        ],
         "opencast_repo_root": "/opt/opencast",
         "opencast_log_directory": "/opt/opencast/log",
         "local_workspace_root": "/var/opencast-workspace",


### PR DESCRIPTION
See OPC-528 for details. This change just fixes the provisioning for new clusters. James intends to update tags for existing resource manually.

Check out jluker-huit-tags2 for an example cluster. 

I used the [aws tag editor](https://console.aws.amazon.com/resource-groups/tag-editor/find-resources?region=us-east-1#) to search for "product:opencast" across all resource types. Doesn't appear to be anything missing from the list, i.e. untagged.

Summary of what I changed:
- moved our standard tags out of the mh-opsworks code/templates and into the `base-secrets.json`, which is incorporated into all new cluster configs
- removed the useless "Project" tag prompt during the `cluster:new` process
- replaced some extra resource tagging code in favour of tagging at the opsworks stack level; aws has improved stack tagging functionality since this project was first created