### PR TITLE
Fix for shell provisioner: * One of inline or path must be set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+* MI-187: additional Vagrant file fix
+
 ## 2.6.0 - 05/07/2020
 
 * OPC-528: update tagging to match HUIT schema

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,15 +20,15 @@ Vagrant.configure("2") do |config|
     inline: "apt-get update"
 
   # enable ubuntu esm
-  config.vm.provision "esm", type: "shell" do |s|
-    esm_token = ENV["UBUNTU_ESM_TOKEN"]
-    if esm_token.nil? && provisioning?
-      print "\nEnter your token to enable Ubuntu ESM, or [Enter] to skip: "
-      esm_token = STDIN.gets.strip.chomp
-    end
-    if esm_token
-      s.inline = "apt-get -y install ubuntu-advantage-tools && ua attach #{esm_token} && apt-get update && apt-get -y upgrade"
-    end
+  esm_token = ENV["UBUNTU_ESM_TOKEN"]
+  if esm_token.nil? && provisioning?
+    print "\nEnter your token to enable Ubuntu ESM, or [Enter] to skip: "
+    esm_token = STDIN.gets.strip.chomp
+  end
+  if esm_token
+    config.vm.provision :shell,
+      name: "enable Ubuntu ESM"
+      inline = "apt-get -y install ubuntu-advantage-tools && ua attach #{esm_token} && apt-get update && apt-get -y upgrade"
   end
 
   config.vm.provision :shell,


### PR DESCRIPTION
@lbjay this fixes the error of "shell provisioner: * One of `path` or `inline` must be set." during "./bin/all_in_one up". But I don't know if it fixes the issue with the ESM token. I was never prompted for the token. 

The install output had this on one of the lines which implies ESM was successful.
```
    all-in-one: [2020-06-01T15:17:10-04:00] INFO: Processing execute[install apt apt-transport-https apt-utils libapt-inst1.5 libapt-pkg4.12 ubuntu-advantage-tools] action run (oc-opsworks-recipes::enable-ubuntu-advantage-esm line 30)
```