### PR TITLE
DEPLOY-54: don't hibernate vpsa if shared with another online cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## TO BE RELEASED
 
+## 2.6.2 - 11/22/2021
+
+* DEPLOY-54: don't hibernate zadara if the vpsa is shared and another cluster using it is online
+
 ## 2.6.1 - 07/20/2021
 
 * deletion process needs to unset deletion protection from the rds cluster
@@ -146,10 +150,10 @@ These changes all relate or were implemented during the Opencast 1.x -> 5.x migr
 ## 1.10.0 - 10/19/2016
 
 * don't use the `--binstubs` flag in `bin/setup`
-* Include new `install-cwlogs` recipe in cluster config templates. 
-  Add IAM policy permissions for managing cloudwatch log groups. 
-  On rollout the "oc-opsworks-cluster-managers" IAM group will need to be manually updated to 
-  include the new "logs:*" and "sqs:*" permissions. Existing clusters will need to run 
+* Include new `install-cwlogs` recipe in cluster config templates.
+  Add IAM policy permissions for managing cloudwatch log groups.
+  On rollout the "oc-opsworks-cluster-managers" IAM group will need to be manually updated to
+  include the new "logs:*" and "sqs:*" permissions. Existing clusters will need to run
   `./bin/rake stack:users:init` to sync their respective cluster manager user.
   Add deletion of additional cluster artifacts, including cloudwatch log groups
   and sqs queues & buckets related to the analytics node.
@@ -177,7 +181,7 @@ These changes all relate or were implemented during the Opencast 1.x -> 5.x migr
 
 * Configure waiters to do "exponential backoff" when waiting for resources
   to become available/deleted.
-* increase `retry_limit` on AWS client objects to alleviate failures due to 
+* increase `retry_limit` on AWS client objects to alleviate failures due to
   API throttling errors
 * Rename of moscaler install recipe in cluster config templates &
   updates to horizontal scaling docs
@@ -262,7 +266,7 @@ These changes all relate or were implemented during the Opencast 1.x -> 5.x migr
 ## 1.0.11 - 2/25/2016
 
 * Open the squid proxy port for rfc 1918 addresses. Document how to set up
-  zadara s3 object backups. This has essentially no effect for clusters that 
+  zadara s3 object backups. This has essentially no effect for clusters that
   don't use zadara object backups (not enabled by default). See README.zadara.md
   for more information.
 

--- a/lib/tasks/stack.rake
+++ b/lib/tasks/stack.rake
@@ -118,18 +118,23 @@ namespace :stack do
       Cluster::Stack.stop_all(stop_rds)
 
       if Cluster::Base.show_zadara_tasks?
-        puts "Hibernating vpsa..."
-        begin
-          Cluster::Zadara.hibernate
-          sleep 60
-
-          while !Cluster::Zadara.is_hibernated?
+        # don't hibernate if another online cluster is using the vpsa
+        if Cluster::Zadara.check_if_shared_with_another_online_cluster
+          puts "Not hibernating vpsa"
+        else
+          puts "Hibernating vpsa..."
+          begin
+            Cluster::Zadara.hibernate
             sleep 60
-          end
 
-          puts "vpsa is hibernated!"
-        rescue Exception => e
-          puts "Something went wrong hibernating vpsa: #{e}"
+            while !Cluster::Zadara.is_hibernated?
+              sleep 60
+            end
+
+            puts "vpsa is hibernated!"
+          rescue Exception => e
+            puts "Something went wrong hibernating vpsa: #{e}"
+          end
         end
       end
     end


### PR DESCRIPTION
This is to address the problem where two clusters might both be using our OCDEV vpsa, but when you shut down one it automatically hibernates the VPSA. This adds a check before the hibernation to confirm no other cluster that is sharing the vpsa has any online instances. It's not terribly sophisticated but it was easy to implement and will prevent the worst case of zadara suddenly going away while the staging cluster is being used.