### PR TITLE
Support cluster configuration for prebuilt opencast deployments:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+- DEPLOY-76: Support cluster configuration for prebuilt opencast deployments
+
 ## 3.0.1 - 03/16/2022
 
 - DEPLOY-68: clean up vpc peering route table entries on cluster deletion

--- a/README.md
+++ b/README.md
@@ -794,6 +794,26 @@ Example config:
 
 To add peering connections to an existing cluster/VPC, add the `peer_vpcs` configuration to the cluster config's custom json and run `./bin/rake vcp:init`
 
+### Deploying pre-built Opencast
+
+By default the Opsworks deployment of the Opencast "app" will check out the revision specified in your cluster config (`app.app_source.revision`) and run the `mvn` command to built from source. It is also possible to deploy pre-built artifacts (e.g. created by an AWS CodeBuild project) from an s3 bucket. This option is not only faster, it also removes the reliance on maven fetching the various dependencies during deployment, and is therefore recommended for a production environment.
+
+A valid configuration for using prebuilt artifacts looks like this:
+```
+"oc_prebuilt_artifacts": {
+  "enable": "true",
+  "bucket": "my-prebuilt-oc-artifacts-bucket"
+},
+```
+
+If `oc_prebuilt_artifacts.enable` is "true" the cluster config sanity checking will validate this configuration by verifying the bucket and necessary artifacts exist. The artifacts are expected to exist at an s3 location like
+
+`s3://[bucket name]/[branch or tag]/[node profile].tgz`
+
+where `node_profile` is one of "admin", "presentation" or "worker". The config check will complain with a WARNING if the bucket or any expected objects are missing.
+
+If use of prebuilt artifacts is enabled, at deploy time the deployment recipes in mh-opsworks-recipes will fetch and extract the gzipped tar archives into the `current_deploy_root` location instead of running maven. The archives contain the complete distribution, including compiled jar files. Everything else works the same, e.g. the `current` symlink will point to the new release path, configuration files and templates will be processed, etc.
+
 ## TODO
 
 * Automate cloudfront distribution creation

--- a/lib/cluster.rb
+++ b/lib/cluster.rb
@@ -61,6 +61,7 @@ require './lib/cluster/config_checks/json_format'
 require './lib/cluster/config_checks/bucket_configs'
 require './lib/cluster/config_checks/real_users'
 require './lib/cluster/config_checks/secrets_ips'
+require './lib/cluster/config_checks/prebuilt_oc'
 require './lib/cluster/zadara'
 
 module Cluster

--- a/lib/cluster/config_checks/prebuilt_oc.rb
+++ b/lib/cluster/config_checks/prebuilt_oc.rb
@@ -1,0 +1,42 @@
+module Cluster
+  module ConfigChecks
+    class MisconfiguredPrebuiltOcSettings < StandardError; end
+
+    class PrebuiltOcSettings < Base
+      def self.sane?
+        oc_prebuilt_artifacts = stack_custom_json.fetch(:oc_prebuilt_artifacts, {})
+
+        if !oc_prebuilt_artifacts.empty? && is_truthy(oc_prebuilt_artifacts[:enable])
+          if oc_prebuilt_artifacts[:bucket].nil? || oc_prebuilt_artifacts[:bucket].empty?
+            raise MisconfiguredPrebuiltOcSettings.new("oc_prebuilt_artifacts misconfigured: missing a `bucket` value")
+          end
+
+          app_revision = app_config[:app_source][:revision]
+          bucket = oc_prebuilt_artifacts[:bucket]
+
+          begin
+            bucket_exists = s3_client.head_bucket({
+              bucket: bucket
+            })
+          rescue
+            STDERR.puts "WARNING: oc_prebuilt_artifacts misconfigured: bucket '#{bucket}' not found!".colorize(:background => :red)
+          end
+
+          ['admin', 'presentation', 'worker'].each do |node_profile|
+            key = "#{app_revision.gsub(/\//, "-")}/#{node_profile}.tgz"
+            begin
+              artifact_object = s3_client.head_object({
+                bucket: bucket,
+                key: key
+              })
+            rescue
+            STDERR.puts "oc_prebuild_artifacts misconfigured: prebuild artifact '#{key}' not found in bucket '#{bucket}'!".colorize(:background => :red)
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+Cluster::Config.append_to_check_registry(Cluster::ConfigChecks::PrebuiltOcSettings)

--- a/lib/cluster/config_creation_session.rb
+++ b/lib/cluster/config_creation_session.rb
@@ -2,7 +2,8 @@ module Cluster
   class ConfigCreationSession
     attr_accessor :variant, :name, :cidr_block_root, :git_url, :git_revision,
       :export_root, :nfs_server_host, :subnet_azs,
-      :include_analytics, :cookbook_revision, :include_utility, :sns_email
+      :include_analytics, :cookbook_revision, :include_utility, :sns_email,
+      :use_prebuilt_artifacts, :prebuilt_artifacts_bucket
 
     def choose_variant
       puts "\nPlease choose the size of the cluster you'd like to deploy.\n\n"
@@ -134,6 +135,29 @@ module Cluster
         @git_revision = 'master'
       else
         @git_revision = git_revision
+      end
+    end
+
+    def get_prebuilt_artifact_bucket
+      print "\nName of the s3 bucket where prebuilt Opencast artifacts are stored: "
+      bucket = STDIN.gets.strip.chomp
+      unless bucket.empty?
+        @prebuilt_artifacts_bucket = bucket
+      else
+        puts "You must enter a bucket name"
+        get_prebuilt_artifact_bucket
+      end
+    end
+
+    def get_use_prebuilt_artifacts
+      print "\nUse prebuilt Opencast? [y/N]: "
+      use_prebuilt_artifacts = STDIN.gets.strip.chomp
+
+      if use_prebuilt_artifacts.downcase == 'y'
+        @use_prebuilt_artifacts = true
+        get_prebuilt_artifact_bucket
+      else
+        @use_prebuilt_artifacts = false
       end
     end
 

--- a/lib/cluster/configuration_helpers.rb
+++ b/lib/cluster/configuration_helpers.rb
@@ -135,6 +135,10 @@ module Cluster
       def peer_vpc_config
         stack_custom_json[:peer_vpcs]
       end
+
+      def is_truthy(val)
+        return ['true', '1'].include? val.to_s.downcase
+      end
     end
 
     def self.included(base)

--- a/lib/tasks/cluster.rake
+++ b/lib/tasks/cluster.rake
@@ -21,7 +21,7 @@ namespace :cluster do
       puts
       puts "You're trying to create or apply a cluster seed and we're not certain"
       puts "if you're on a development or testing cluster or not."
-      puts 
+      puts
       puts 'If you are, Please set "cluster_env" to "development" or "test" in your'
       puts "cluster configuration's custom_json and try again."
       puts
@@ -197,8 +197,11 @@ namespace :cluster do
     session.get_cluster_name
     session.sns_email_subscription
     session.get_cookbook_revision
+
     session.get_git_url
+
     session.get_git_revision
+    session.get_use_prebuilt_artifacts
     session.compute_cidr_block_root
     session.compute_azs
 
@@ -220,7 +223,9 @@ namespace :cluster do
       include_analytics: session.include_analytics,
       cookbook_revision: session.cookbook_revision,
       include_utility: session.include_utility,
-      sns_email: session.sns_email
+      sns_email: session.sns_email,
+      use_prebuilt_artifacts: session.use_prebuilt_artifacts,
+      prebuilt_artifact_bucket: session.prebuilt_artifacts_bucket || ""
     )
     rc_file = Cluster::RcFileSwitcher.new(config_file: config_file)
     rc_file.write

--- a/templates/cluster_config_default.json.erb
+++ b/templates/cluster_config_default.json.erb
@@ -31,6 +31,10 @@
         "base_public_ami_id": "<%= base_public_ami_id %>",
         "base_private_ami_id": "<%= base_private_ami_id %>",
         <% end %>
+        "oc_prebuilt_artifacts": {
+          "enable": "<%= use_prebuilt_artifacts %>",
+          "bucket": "<%= prebuilt_artifact_bucket %>"
+        },
         "sns_endpoints": [
           { "email": "<%= sns_notification_email %>"}
         ],

--- a/templates/cluster_config_zadara.json.erb
+++ b/templates/cluster_config_zadara.json.erb
@@ -31,6 +31,10 @@
         "base_public_ami_id": "<%= base_public_ami_id %>",
         "base_private_ami_id": "<%= base_private_ami_id %>",
         <% end %>
+        "oc_prebuilt_artifacts": {
+          "enable": "<%= use_prebuilt_artifacts %>",
+          "bucket": "<%= prebuilt_artifact_bucket %>"
+        },
         "sns_endpoints": [
           { "email": "<%= sns_notification_email %>"}
         ],


### PR DESCRIPTION
- additional `cluster:new` prompts
- updates to base and zadara cluster config templates
- config test sanity checker