### PR TITLE
consolidate prebuilt opencast cookbook and software builds

### DIFF
--- a/lib/cluster/config.rb
+++ b/lib/cluster/config.rb
@@ -36,11 +36,16 @@ module Cluster
       JSON.parse(secrets_content, symbolize_names: true)
     end
 
-    def sane?
+    def sane?(verify_prebuilt_artifacts)
       errors = []
       begin
         self.class.check_registry.each do |klass|
           klass.sane?
+        end
+        if verify_prebuilt_artifacts
+          self.class.prebuilt_artifacts_check_registry.each do |klass|
+            klass.sane?
+          end
         end
       rescue => e
         errors << e
@@ -61,6 +66,14 @@ module Cluster
 
     def self.check_registry
       @@check_registry ||= []
+    end
+
+    def self.append_to_prebuilt_artifacts_check_registry(klass)
+      prebuilt_artifacts_check_registry << klass
+    end
+
+    def self.prebuilt_artifacts_check_registry
+      @@prebuilt_artifacts_check_registry ||= []
     end
 
     private

--- a/lib/cluster/config_creation_session.rb
+++ b/lib/cluster/config_creation_session.rb
@@ -2,8 +2,7 @@ module Cluster
   class ConfigCreationSession
     attr_accessor :variant, :name, :cidr_block_root, :git_url, :git_revision,
       :export_root, :nfs_server_host, :subnet_azs,
-      :include_analytics, :cookbook_revision, :include_utility, :sns_email,
-      :use_prebuilt_artifacts, :prebuilt_artifacts_bucket
+      :include_analytics, :cookbook_revision, :include_utility, :sns_email
 
     def choose_variant
       puts "\nPlease choose the size of the cluster you'd like to deploy.\n\n"
@@ -135,29 +134,6 @@ module Cluster
         @git_revision = 'master'
       else
         @git_revision = git_revision
-      end
-    end
-
-    def get_prebuilt_artifact_bucket
-      print "\nName of the s3 bucket where prebuilt Opencast artifacts are stored: "
-      bucket = STDIN.gets.strip.chomp
-      unless bucket.empty?
-        @prebuilt_artifacts_bucket = bucket
-      else
-        puts "You must enter a bucket name"
-        get_prebuilt_artifact_bucket
-      end
-    end
-
-    def get_use_prebuilt_artifacts
-      print "\nUse prebuilt Opencast? [y/N]: "
-      use_prebuilt_artifacts = STDIN.gets.strip.chomp
-
-      if use_prebuilt_artifacts.downcase == 'y'
-        @use_prebuilt_artifacts = true
-        get_prebuilt_artifact_bucket
-      else
-        @use_prebuilt_artifacts = false
       end
     end
 

--- a/lib/cluster/configuration_helpers.rb
+++ b/lib/cluster/configuration_helpers.rb
@@ -125,7 +125,15 @@ module Cluster
 
       def get_cookbook_source_s3_url(revision)
         revision_file_label = revision.gsub("/", "-")
-        %Q|https://s3.amazonaws.com/#{shared_asset_bucket_name}/cookbooks/mh-opsworks-recipes-#{revision_file_label}.tar.gz|
+        prebuilt_artifacts_config = stack_custom_json.fetch(:oc_prebuilt_artifacts, {})
+
+        use_new_artifacts_bucket = !prebuilt_artifacts_config.empty?
+        if use_new_artifacts_bucket
+          prebuilt_artifacts_bucket = prebuilt_artifacts_config[:bucket]
+          %Q|https://#{prebuilt_artifacts_bucket}.s3.amazonaws.com/cookbook/#{revision_file_label}/mh-opsworks-recipes-#{revision_file_label}.tar.gz|
+        else
+          %Q|https://#{shared_asset_bucket_name}.s3.amazonaws.com/cookbooks/mh-opsworks-recipes-#{revision_file_label}.tar.gz|
+        end
       end
 
       def ibm_watson_config

--- a/lib/tasks/docs/cluster:edit.txt
+++ b/lib/tasks/docs/cluster:edit.txt
@@ -13,6 +13,7 @@ make changes.
 After you save and exit, it:
 
 * Runs 'cluster:configtest' to sanity check your config changes,
+* Verifies the existence of any prebuilt opencast and/or cookbook objects in s3
 * Shows you a diff of the changes, allowing you to confirm them,
 * Syncs the cluster config to the shared s3 bucket, and then
 * Syncs the configuration to the connected AWS environment

--- a/templates/cluster_config_default.json.erb
+++ b/templates/cluster_config_default.json.erb
@@ -31,10 +31,6 @@
         "base_public_ami_id": "<%= base_public_ami_id %>",
         "base_private_ami_id": "<%= base_private_ami_id %>",
         <% end %>
-        "oc_prebuilt_artifacts": {
-          "enable": "<%= use_prebuilt_artifacts %>",
-          "bucket": "<%= prebuilt_artifact_bucket %>"
-        },
         "sns_endpoints": [
           { "email": "<%= sns_notification_email %>"}
         ],

--- a/templates/cluster_config_zadara.json.erb
+++ b/templates/cluster_config_zadara.json.erb
@@ -31,10 +31,6 @@
         "base_public_ami_id": "<%= base_public_ami_id %>",
         "base_private_ami_id": "<%= base_private_ami_id %>",
         <% end %>
-        "oc_prebuilt_artifacts": {
-          "enable": "<%= use_prebuilt_artifacts %>",
-          "bucket": "<%= prebuilt_artifact_bucket %>"
-        },
         "sns_endpoints": [
           { "email": "<%= sns_notification_email %>"}
         ],


### PR DESCRIPTION
- configtest now verifies cookbook and opencast packages in configured bucket
- cookbook url generation falls back to previous location (shared assets bucket) if the new prebuilt artifacts bucket configuration is not present.

For context, the cluster config section for using prebuilt opencast and/or cookbooks looks like:
```
        "oc_prebuilt_artifacts": {
          "enable": "true",
          "bucket": "opencast-codebuild-artifacts"
        },
```

If `enable` is true then two things will happen:
- locally, when editing your cluster config, `lib/cluster/config_checks/prebuilt_oc.rb` will sanity check that the prebuilt artifacts that correspond to your configured opencast revision are actually present in the s3 bucket. You'll get a green checkmark message if everything is cool, and a red WARNING if the objects don't exist. **Note** that it won't fail outright as there could be situations where you're editing your config before the artifacts are done building.
- at deploy time the deploy recipes will fetch and extract the prebuilt opencast .tgz files instead of running the maven command.

If `bucket` is defined **and** your `custom_cookbook_source.type` is set to "s3" (should be already):
- the same kind of local sanity check to verify the cookbook artifact exists
- when you save your cluster config the cluster's opsworks stack configuration will be set to use the prepackaged cookbook from the new artifacts bucket.