### PR TITLE
Jluker cluster deletion fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TO BE RELEASED
 
+- properly delete vpc peering route table entries
+
 ## 4.1.0 - 01/22/2024
 
 - add creation of cold-archive bucket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## TO BE RELEASED
 
 - properly delete vpc peering route table entries
+- set a consistent DeletionPolicy for RDS resources based on stack type (dev, stage, or prod)
 
 ## 4.1.0 - 01/22/2024
 

--- a/lib/cluster/configuration_helpers.rb
+++ b/lib/cluster/configuration_helpers.rb
@@ -147,6 +147,18 @@ module Cluster
       def is_truthy(val)
         return ['true', '1'].include? val.to_s.downcase
       end
+
+      def stage_cluster?
+        stack_shortname.match?(/stage|staging|stg/i)
+      end
+
+      def retain_db?
+        rds_config.fetch('retain_on_delete', false)
+      end
+
+      def db_deletion_policy
+        (prod_cluster? or stage_cluster? or retain_db?) ? "Retain" : "Delete"
+      end
     end
 
     def self.included(base)

--- a/lib/cluster/console.rb
+++ b/lib/cluster/console.rb
@@ -1,3 +1,4 @@
+require 'pry'
 module Cluster
   class Console < Base
     def self.run

--- a/lib/cluster/rds.rb
+++ b/lib/cluster/rds.rb
@@ -196,6 +196,10 @@ module Cluster
           {
               parameter_key: "SnsTopicArn",
               parameter_value: get_topic_arn
+          },
+          {
+            parameter_key: "DBDeletionPolicy",
+            parameter_value: db_deletion_policy
           }
       ]
 

--- a/templates/RDSCluster.template.yml
+++ b/templates/RDSCluster.template.yml
@@ -42,6 +42,9 @@ Parameters:
   BackupRetentionPeriod:
     Description: 'Number of days to keep automated backups'
     Type: 'String'
+  DBDeletionPolicy:
+    Description: 'Retain or Delete DB resources during stack deletion (Retain for prod & staging only)'
+    Type: 'String'
 
 Conditions:
   CreateReplica: !Not [!Equals [!Ref MultiAZ, 'false']]
@@ -49,6 +52,7 @@ Conditions:
 Resources:
   DBSubnetGroup:
     Type: 'AWS::RDS::DBSubnetGroup'
+    DeletionPolicy: !Ref DBDeletionPolicy
     Properties:
       DBSubnetGroupDescription: !Sub '${AWS::StackName} db subnet group'
       SubnetIds:
@@ -59,6 +63,7 @@ Resources:
 
   DBClusterParameterGroup57:
     Type: 'AWS::RDS::DBClusterParameterGroup'
+    DeletionPolicy: !Ref DBDeletionPolicy
     Properties:
       Description: !Sub '${AWS::StackName} cluster-level settings'
       Family: 'aurora-mysql5.7'
@@ -74,6 +79,7 @@ Resources:
 
   DBParameterGroup57:
     Type: 'AWS::RDS::DBParameterGroup'
+    DeletionPolicy: !Ref DBDeletionPolicy
     Properties:
       Description: !Sub '${AWS::StackName} instance-level settings'
       Family: 'aurora-mysql5.7'
@@ -86,7 +92,8 @@ Resources:
     Type: 'AWS::RDS::DBCluster'
     # This attribute indicates what to do with the resource when the Cfn stack is deleted
     # default for rds clusters is "Snapshot" but that would interfere with our automated processes
-    DeletionPolicy: Retain
+    DeletionPolicy: !Ref DBDeletionPolicy
+    DependsOn: [DBParameterGroup57, DBClusterParameterGroup57, DBSubnetGroup]
     Properties:
       DBClusterIdentifier: !Ref DBClusterIdentifier
       BackupRetentionPeriod: !Ref BackupRetentionPeriod
@@ -116,7 +123,8 @@ Resources:
   DBInstance1:
     Type: 'AWS::RDS::DBInstance'
     # See note on the cluster resource
-    DeletionPolicy: Retain
+    DeletionPolicy: !Ref DBDeletionPolicy
+    DependsOn: [DBParameterGroup57, DBClusterParameterGroup57, DBSubnetGroup]
     Properties:
       AutoMinorVersionUpgrade: false
       CopyTagsToSnapshot: true
@@ -132,7 +140,8 @@ Resources:
   DBInstance2:
     Type: 'AWS::RDS::DBInstance'
     # See note on the cluster resource
-    DeletionPolicy: Retain
+    DeletionPolicy: !Ref DBDeletionPolicy
+    DependsOn: [DBParameterGroup57, DBClusterParameterGroup57, DBSubnetGroup]
     Condition: CreateReplica
     Properties:
       AutoMinorVersionUpgrade: false
@@ -153,7 +162,7 @@ Resources:
     # rds cluster was started because it was hibernated for longer than
     # the 7 day max set by AWS, and then turns them off again
     Type: 'AWS::RDS::EventSubscription'
-    DeletionPolicy: Retain
+    DeletionPolicy: !Ref DBDeletionPolicy
     Properties:
       EventCategories:
         - failover
@@ -190,3 +199,8 @@ Outputs:
     Value: !Ref DBClusterEventSubscription
     Export:
       Name: !Sub '${AWS::StackName}-rds-event-subscription'
+  DBDeletionPolicy:
+    Description: 'Deletion policy for db resources'
+    Value: !Ref DBDeletionPolicy
+    Export:
+      Name: !Sub '${AWS::StackName}-rds-deletion-policy'


### PR DESCRIPTION
This fixes the vpc peering route deletion bug and the issue that's prevented clusters from deleting cleanly for awhile.